### PR TITLE
docs: Add a workaround to installing grpc for ARM Macs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
     $ gem install momento
 
+### M1 or M2 Macs
+
+If you're using an M1 or M2 Mac, [you may have trouble installing the `grpc` gem](https://github.com/grpc/grpc/issues/31215).
+
+[A work around](https://github.com/grpc/grpc/pull/31151#issuecomment-1310321807) is to run `bundle config build.grpc --with-ldflags="-Wl,-undefined,dynamic_lookup"` before doing `bundle install`.
+
 ## Requirements
 
 * A Momento Auth Token is required, you can generate one using the Momento CLI


### PR DESCRIPTION
The grpc gem does not work on M1/M2 Macs. Document the work around in the README.

Closes #36 