### PR TITLE
docs: Use MOMENTO_AUTH_TOKEN for consistency with other SDKs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
 require 'momento'
 
 # Get your Momento token from an environment variable.
-token = ENV.fetch('MOMENTO_TOKEN')
+token = ENV.fetch('MOMENTO_AUTH_TOKEN')
 
 # Cached items will be deleted after 30 seconds.
 ttl = 30_000

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -1,7 +1,7 @@
 require 'momento'
 
 # Get your Momento token from an environment variable.
-token = ENV.fetch('MOMENTO_TOKEN')
+token = ENV.fetch('MOMENTO_AUTH_TOKEN')
 
 # Cached items will be deleted after 30 seconds.
 ttl = 30_000


### PR DESCRIPTION
Closes #33