### PR TITLE
build: Fix passing arguments to semantic-release-action

### DIFF
--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -35,14 +35,12 @@ jobs:
       - uses: codfish/semantic-release-action@v2
         id: semrel
         with:
-          branches:
-            - release
-          plugins:
-            - '@semantic-release/commit-analyzer'
-            - '@semantic-release/release-notes-generator'
-            - '@semantic-release-rubygem'
-          additional_packages:
-            - semantic-release-rubygem
+          branches: |
+            ['release']
+          plugins: |
+            ['@semantic-release/commit-analyzer', '@semantic-release/release-notes-generator', '@semantic-release-rubygem']
+          additional_packages: |
+            ['@semantic-release-rubygem']
         env:
           GITHUB_TOKEN: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_PUBLISH_TOKEN}}


### PR DESCRIPTION
YAML has perfectly good arrays. Why they want arrays as strings, I have no idea. But that's what the docs say.