### PR TITLE
build: Fix passing the version through to gem bump.

### DIFF
--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Run tests
       run: bundle exec rspec
 
-  publish:
+  get_version:
     runs-on: ubuntu-latest
-    needs:
-      - test
+    outputs:
+      version: ${{ steps.semrel.outputs.version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -37,8 +37,6 @@ jobs:
       - uses: go-semantic-release/action@v1
         id: semrel
         with:
-          branches: |
-            ['release']
           # We only want the version #.
           dry: true
           github-token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
@@ -49,7 +47,16 @@ jobs:
       - name: Show release version
         if: ${{ success() }}
         run: |
-          echo $RELEASE_VERSION
+          echo ${{ steps.semrel.outputs.version }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [test, get_version]
+    env:
+      RELEASE_VERSION: ${{ needs.get_version.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby
         if: ${{ success() }}
@@ -65,7 +72,7 @@ jobs:
       - name: Bump version and tag
         if: ${{ success() }}
         run: |
-          gem bump -v $RELEASE_VERSION
+          gem bump -t -v $RELEASE_VERSION
 
       - uses: cadwallion/publish-rubygems-action@master
         if: ${{ success() }}


### PR DESCRIPTION
Seems go-semantic-version doesn't set any environment variables. We need to output it ourselves.

* go-semantic-version doesn't have `branches`
* Don't forget to set the tag.