### PR TITLE
docs: Use response.value rather than the stringification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ end
 # And get it back.
 response = client.get("test_cache", "key")
 if response.hit?
-  puts "Cache returned: #{response}"
+  puts "Cache returned: #{response.value}"
 elsif response.miss?
   puts "The item wasn't found in the cache."
 elsif response.error?

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -35,7 +35,7 @@ end
 # And get it back.
 response = client.get("test_cache", "key")
 if response.hit?
-  puts "Cache returned: #{response}"
+  puts "Cache returned: #{response.value}"
 elsif response.miss?
   puts "The item wasn't found in the cache."
 elsif response.error?


### PR DESCRIPTION
to_s will truncate the output, and get doesn't necessarily return a human readable string.

Closes #45