### PR TITLE
build: Remove release-please config from the Github action.

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,10 +14,6 @@ jobs:
         id: release
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
-          release-type: ruby
-          package-name: momento
-          bump-minor-pre-major: true
-          version-file: lib/momento/version.rb
 
       # The rest happens *after* the release PR is merged.
       - uses: actions/checkout@v3


### PR DESCRIPTION
It lives in release-please-config.json now.