### PR TITLE
feature: Make #value discoverable

### DIFF
--- a/lib/momento/get_response.rb
+++ b/lib/momento/get_response.rb
@@ -35,10 +35,12 @@ module Momento
       end
     end
 
+    # @return [Boolean] did we get a value
     def hit?
       false
     end
 
+    # @return [Boolean] was there no value
     def miss?
       false
     end

--- a/lib/momento/get_response.rb
+++ b/lib/momento/get_response.rb
@@ -45,6 +45,11 @@ module Momento
       false
     end
 
+    # @return [String,nil] the gotten value, if any.
+    def value
+      nil
+    end
+
     # Successfully got an item from the cache.
     class Hit < GetResponse
       # rubocop:disable Lint/MissingSuper
@@ -57,7 +62,6 @@ module Momento
         true
       end
 
-      # @return [String] the value from the cache
       def value
         @grpc_response.cache_body
       end

--- a/spec/momento/get_response_spec.rb
+++ b/spec/momento/get_response_spec.rb
@@ -48,4 +48,10 @@ RSpec.describe Momento::GetResponse do
       end
     end
   end
+
+  describe '#value' do
+    it 'is nil' do
+      expect(response.value).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
`get` is docuented to return a GetResponse. IDEs won't see it if it's only in a subclass. Add it to GetResponse.

Closes #44 