### PR TITLE
refactor: Misc refactor cleanups

### DIFF
--- a/lib/momento/create_cache_response_builder.rb
+++ b/lib/momento/create_cache_response_builder.rb
@@ -17,7 +17,7 @@ module Momento
     rescue GRPC::AlreadyExists
       return CreateCacheResponse::AlreadyExists.new
     rescue GRPC::BadStatus => e
-      CreateCacheResponse::Error.new(grpc_exception: e)
+      CreateCacheResponse::Error.new(exception: e)
     else
       raise TypeError unless response.is_a?(::Momento::ControlClient::CreateCacheResponse)
 

--- a/lib/momento/delete_cache_response_builder.rb
+++ b/lib/momento/delete_cache_response_builder.rb
@@ -15,7 +15,7 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      DeleteCacheResponse::Error.new(grpc_exception: e)
+      DeleteCacheResponse::Error.new(exception: e)
     else
       raise TypeError unless response.is_a?(::Momento::ControlClient::DeleteCacheResponse)
 

--- a/lib/momento/delete_response_builder.rb
+++ b/lib/momento/delete_response_builder.rb
@@ -15,7 +15,7 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      DeleteResponse::Error.new(grpc_exception: e)
+      DeleteResponse::Error.new(exception: e)
     else
       raise TypeError unless response.is_a?(::Momento::CacheClient::DeleteResponse)
 

--- a/lib/momento/get_response_builder.rb
+++ b/lib/momento/get_response_builder.rb
@@ -16,7 +16,7 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      GetResponse::Error.new(grpc_exception: e)
+      GetResponse::Error.new(exception: e)
     else
       from_response(response)
     end

--- a/lib/momento/list_caches_response_builder.rb
+++ b/lib/momento/list_caches_response_builder.rb
@@ -15,7 +15,7 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      ListCachesResponse::Error.new(grpc_exception: e)
+      ListCachesResponse::Error.new(exception: e)
     else
       raise TypeError unless response.is_a?(::Momento::ControlClient::ListCachesResponse)
 

--- a/lib/momento/response/error.rb
+++ b/lib/momento/response/error.rb
@@ -2,10 +2,10 @@ module Momento
   class Response
     # A module for responses which contain errors.
     module Error
-      attr_accessor :grpc_exception
+      attr_reader :exception
 
-      def initialize(grpc_exception:)
-        @grpc_exception = grpc_exception
+      def initialize(exception:)
+        @exception = exception
       end
 
       def error?

--- a/lib/momento/set_response_builder.rb
+++ b/lib/momento/set_response_builder.rb
@@ -15,7 +15,7 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      SetResponse::Error.new(grpc_exception: e)
+      SetResponse::Error.new(exception: e)
     else
       raise TypeError unless response.is_a?(::Momento::CacheClient::SetResponse)
 

--- a/lib/momento/simple_cache_client.rb
+++ b/lib/momento/simple_cache_client.rb
@@ -161,7 +161,7 @@ module Momento
 
         loop do
           response = list_caches(next_token: next_token)
-          raise response.grpc_exception if response.is_a? Momento::Response::Error
+          raise response.exception if response.is_a? Momento::Response::Error
 
           response.cache_names.each do |name|
             yielder << name

--- a/spec/factories/momento/response.rb
+++ b/spec/factories/momento/response.rb
@@ -5,36 +5,8 @@ FactoryBot.define do
     initialize_with { new(**attributes) }
   end
 
-  trait :momento_response_success do
-    initialize_with { new(grpc_response) }
-  end
-
   trait :momento_response_error do
     momento_response
-
-    grpc_exception { GRPC::PermissionDenied.new }
-  end
-
-  trait :momento_response_already_exists do
-    momento_response_error
-
-    grpc_exception { GRPC::AlreadyExists.new }
-  end
-
-  trait :momento_response_invalid_argument do
-    momento_response_error
-
-    grpc_exception { GRPC::InvalidArgument.new }
-  end
-
-  trait :momento_response_not_found do
-    momento_response_error
-
-    grpc_exception { GRPC::NotFound.new }
-  end
-
-  trait :momento_response_permission_denied do
-    momento_response_error
 
     grpc_exception { GRPC::PermissionDenied.new }
   end

--- a/spec/factories/momento/response.rb
+++ b/spec/factories/momento/response.rb
@@ -8,6 +8,6 @@ FactoryBot.define do
   trait :momento_response_error do
     momento_response
 
-    grpc_exception { GRPC::PermissionDenied.new }
+    exception { GRPC::PermissionDenied.new }
   end
 end

--- a/spec/momento/simple_cache_client_spec.rb
+++ b/spec/momento/simple_cache_client_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe Momento::SimpleCacheClient do
 
       expect {
         client.caches.to_a
-      }.to raise_error(error_response.grpc_exception)
+      }.to raise_error(error_response.exception)
     end
 
     it 'when list_caches raises, it raises' do
@@ -344,7 +344,7 @@ RSpec.describe Momento::SimpleCacheClient do
           expect(
             client.get("name", "key")
           ).to be_a(Momento::GetResponse::Error).and have_attributes(
-            grpc_exception: exception
+            exception: exception
           )
         end
       end
@@ -450,7 +450,7 @@ RSpec.describe Momento::SimpleCacheClient do
           expect(
             client.set("name", "key", "value")
           ).to be_a(Momento::SetResponse::Error).and have_attributes(
-            grpc_exception: exception
+            exception: exception
           )
         end
       end
@@ -533,7 +533,7 @@ RSpec.describe Momento::SimpleCacheClient do
           expect(
             client.delete("name", "key")
           ).to be_a(Momento::DeleteResponse::Error).and have_attributes(
-            grpc_exception: exception
+            exception: exception
           )
         end
       end

--- a/spec/support/shared_examples/momento/response/from_block.rb
+++ b/spec/support/shared_examples/momento/response/from_block.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples 'it wraps gRPC exceptions' do
 
   it 'wraps the exception' do
     expect(
-      described_class.from_block { raise exception }.grpc_exception
+      described_class.from_block { raise exception }.exception
     ).to eq exception
   end
 

--- a/spec/support/shared_examples/momento/response_builder.rb
+++ b/spec/support/shared_examples/momento/response_builder.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples '#from_block wraps gRPC exceptions' do
 
   it 'wraps the exception' do
     expect(
-      builder.from_block { raise exception }.grpc_exception
+      builder.from_block { raise exception }.exception
     ).to eq exception
   end
 


### PR DESCRIPTION
Some misc refactorings to cut down the complexity of #6.

* Remove unused test factory response traits.
* Rename grpc_exception -> exception, we no longer assume it is a GRPC exception.