### PR TITLE
test: Push checking common Momento::Response attributes down.

### DIFF
--- a/spec/momento/create_cache_response/already_exists_spec.rb
+++ b/spec/momento/create_cache_response/already_exists_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::CreateCacheResponse::AlreadyExists do
   }
 
   it_behaves_like Momento::CreateCacheResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { already_exists?: true }
     end
   end

--- a/spec/momento/create_cache_response/error_spec.rb
+++ b/spec/momento/create_cache_response/error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::CreateCacheResponse::Error do
   }
 
   it_behaves_like Momento::CreateCacheResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { error?: true }
     end
   end

--- a/spec/momento/create_cache_response/success_spec.rb
+++ b/spec/momento/create_cache_response/success_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::CreateCacheResponse::Success do
   }
 
   it_behaves_like Momento::CreateCacheResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { success?: true }
     end
   end

--- a/spec/momento/create_cache_response_spec.rb
+++ b/spec/momento/create_cache_response_spec.rb
@@ -3,8 +3,5 @@ require 'momento/response'
 RSpec.describe Momento::CreateCacheResponse do
   let(:response) { described_class.new }
 
-  it_behaves_like Momento::Response
-  it_behaves_like described_class do
-    let(:types) do {} end
-  end
+  it_behaves_like described_class
 end

--- a/spec/momento/delete_cache_response/error_spec.rb
+++ b/spec/momento/delete_cache_response/error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::DeleteCacheResponse::Error do
   }
 
   it_behaves_like Momento::DeleteCacheResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { error?: true }
     end
   end

--- a/spec/momento/delete_cache_response/success_spec.rb
+++ b/spec/momento/delete_cache_response/success_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::DeleteCacheResponse::Success do
   }
 
   it_behaves_like Momento::DeleteCacheResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { success?: true }
     end
   end

--- a/spec/momento/delete_cache_response_spec.rb
+++ b/spec/momento/delete_cache_response_spec.rb
@@ -3,8 +3,5 @@ require 'momento/response'
 RSpec.describe Momento::DeleteCacheResponse do
   let(:response) { described_class.new }
 
-  it_behaves_like Momento::Response
-  it_behaves_like described_class do
-    let(:types) do {} end
-  end
+  it_behaves_like described_class
 end

--- a/spec/momento/delete_response/error_spec.rb
+++ b/spec/momento/delete_response/error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::DeleteResponse::Error do
   }
 
   it_behaves_like Momento::DeleteResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { error?: true }
     end
   end

--- a/spec/momento/delete_response/success_spec.rb
+++ b/spec/momento/delete_response/success_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::DeleteResponse::Success do
   }
 
   it_behaves_like Momento::DeleteResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { success?: true }
     end
   end

--- a/spec/momento/delete_response_spec.rb
+++ b/spec/momento/delete_response_spec.rb
@@ -3,8 +3,5 @@ require 'momento/response'
 RSpec.describe Momento::DeleteResponse do
   let(:response) { described_class.new }
 
-  it_behaves_like Momento::Response
-  it_behaves_like described_class do
-    let(:types) do {} end
-  end
+  it_behaves_like described_class
 end

--- a/spec/momento/get_response/error_spec.rb
+++ b/spec/momento/get_response/error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::GetResponse::Error do
   }
 
   it_behaves_like Momento::GetResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { error?: true }
     end
   end

--- a/spec/momento/get_response/hit_spec.rb
+++ b/spec/momento/get_response/hit_spec.rb
@@ -9,20 +9,12 @@ RSpec.describe Momento::GetResponse::Hit do
   }
 
   it_behaves_like Momento::GetResponse do
-    let(:types) do
-      { hit?: true }
+    let(:subclass_attributes) do
+      {
+        hit?: true,
+        value: grpc_response.cache_body,
+        to_s: response.value
+      }
     end
-  end
-
-  describe '#value' do
-    subject { response.value }
-
-    it { is_expected.to eq grpc_response.cache_body }
-  end
-
-  describe '#to_s' do
-    subject { response.to_s }
-
-    it { is_expected.to eq response.value }
   end
 end

--- a/spec/momento/get_response/miss_spec.rb
+++ b/spec/momento/get_response/miss_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::GetResponse::Miss do
   }
 
   it_behaves_like Momento::GetResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { miss?: true }
     end
   end

--- a/spec/momento/get_response_spec.rb
+++ b/spec/momento/get_response_spec.rb
@@ -3,14 +3,9 @@ require 'momento/response'
 RSpec.describe Momento::GetResponse do
   let(:response) { described_class.new }
 
-  it_behaves_like Momento::Response
   it_behaves_like described_class do
-    let(:types) do {} end
-  end
-
-  describe '#value' do
-    it 'is nil' do
-      expect(response.value).to be_nil
+    let(:superclass_attributes) do
+      { value: nil }
     end
   end
 end

--- a/spec/momento/list_caches_response/error_spec.rb
+++ b/spec/momento/list_caches_response/error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::ListCachesResponse::Error do
   }
 
   it_behaves_like Momento::ListCachesResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { error?: true }
     end
   end

--- a/spec/momento/list_caches_response/success_spec.rb
+++ b/spec/momento/list_caches_response/success_spec.rb
@@ -15,18 +15,12 @@ RSpec.describe Momento::ListCachesResponse::Success do
   }
 
   it_behaves_like Momento::ListCachesResponse do
-    let(:types) do { success?: true } end
-  end
-
-  describe '#cache_names' do
-    subject { response.cache_names }
-
-    it { is_expected.to eq cache_names }
-  end
-
-  describe '#next_token' do
-    subject { response.next_token }
-
-    it { is_expected.to eq next_token }
+    let(:subclass_attributes) do
+      {
+        success?: true,
+        cache_names: cache_names,
+        next_token: next_token
+      }
+    end
   end
 end

--- a/spec/momento/list_caches_response_spec.rb
+++ b/spec/momento/list_caches_response_spec.rb
@@ -1,10 +1,7 @@
 require 'momento/response'
 
 RSpec.describe Momento::ListCachesResponse do
-  let(:response) { described_class.new }
-
-  it_behaves_like Momento::Response
   it_behaves_like described_class do
-    let(:types) do {} end
+    let(:response) { described_class.new }
   end
 end

--- a/spec/momento/set_response/error_spec.rb
+++ b/spec/momento/set_response/error_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::SetResponse::Error do
   }
 
   it_behaves_like Momento::SetResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { error?: true }
     end
   end

--- a/spec/momento/set_response/success_spec.rb
+++ b/spec/momento/set_response/success_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Momento::SetResponse::Success do
   }
 
   it_behaves_like Momento::SetResponse do
-    let(:types) do
+    let(:subclass_attributes) do
       { success?: true }
     end
   end

--- a/spec/momento/set_response_spec.rb
+++ b/spec/momento/set_response_spec.rb
@@ -3,8 +3,5 @@ require 'momento/response'
 RSpec.describe Momento::SetResponse do
   let(:response) { described_class.new }
 
-  it_behaves_like Momento::Response
-  it_behaves_like described_class do
-    let(:types) do {} end
-  end
+  it_behaves_like described_class
 end

--- a/spec/support/shared_examples/momento/create_cache_response.rb
+++ b/spec/support/shared_examples/momento/create_cache_response.rb
@@ -1,25 +1,16 @@
 require 'momento/response'
 
 RSpec.shared_examples Momento::CreateCacheResponse do
-  it 'is a subclass' do
-    expect(response).to be_a described_class
-  end
-
-  describe 'type methods' do
-    subject { response }
-
-    let(:default_types) do
+  it_behaves_like Momento::Response do
+    let(:superclass_attributes) do
       {
         success?: false,
-        already_exists?: false,
-        error?: false
+        already_exists?: false
       }
     end
+  end
 
-    it do
-      is_expected.to have_attributes(
-        default_types.merge(types)
-      )
-    end
+  it 'is a subclass' do
+    expect(response).to be_a described_class
   end
 end

--- a/spec/support/shared_examples/momento/delete_cache_response.rb
+++ b/spec/support/shared_examples/momento/delete_cache_response.rb
@@ -1,24 +1,15 @@
 require 'momento/response'
 
 RSpec.shared_examples Momento::DeleteCacheResponse do
-  it 'is a subclass' do
-    expect(response).to be_a described_class
-  end
-
-  describe 'type methods' do
-    subject { response }
-
-    let(:default_types) do
+  it_behaves_like Momento::Response do
+    let(:superclass_attributes) do
       {
-        success?: false,
-        error?: false
+        success?: false
       }
     end
+  end
 
-    it do
-      is_expected.to have_attributes(
-        default_types.merge(types)
-      )
-    end
+  it 'is a subclass' do
+    expect(response).to be_a described_class
   end
 end

--- a/spec/support/shared_examples/momento/delete_response.rb
+++ b/spec/support/shared_examples/momento/delete_response.rb
@@ -1,24 +1,15 @@
 require 'momento/response'
 
 RSpec.shared_examples Momento::DeleteResponse do
-  it 'is a subclass' do
-    expect(response).to be_a described_class
-  end
-
-  describe 'type methods' do
-    subject { response }
-
-    let(:default_types) do
+  it_behaves_like Momento::Response do
+    let(:superclass_attributes) do
       {
-        success?: false,
-        error?: false
+        success?: false
       }
     end
+  end
 
-    it do
-      is_expected.to have_attributes(
-        default_types.merge(types)
-      )
-    end
+  it 'is a subclass' do
+    expect(response).to be_a described_class
   end
 end

--- a/spec/support/shared_examples/momento/get_response.rb
+++ b/spec/support/shared_examples/momento/get_response.rb
@@ -1,25 +1,16 @@
 require 'momento/response'
 
 RSpec.shared_examples Momento::GetResponse do
-  it 'is a subclass' do
-    expect(response).to be_a described_class
-  end
-
-  describe 'type methods' do
-    subject { response }
-
-    let(:default_types) do
+  it_behaves_like Momento::Response do
+    let(:superclass_attributes) do
       {
         hit?: false,
-        miss?: false,
-        error?: false
+        miss?: false
       }
     end
+  end
 
-    it do
-      is_expected.to have_attributes(
-        default_types.merge(types)
-      )
-    end
+  it 'is a subclass' do
+    expect(response).to be_a described_class
   end
 end

--- a/spec/support/shared_examples/momento/list_caches_response.rb
+++ b/spec/support/shared_examples/momento/list_caches_response.rb
@@ -1,24 +1,15 @@
 require 'momento/response'
 
 RSpec.shared_examples Momento::ListCachesResponse do
-  it 'is a subclass' do
-    expect(response).to be_a described_class
-  end
-
-  describe 'type methods' do
-    subject { response }
-
-    let(:default_types) do
+  it_behaves_like Momento::Response do
+    let(:superclass_attributes) do
       {
-        success?: false,
-        error?: false
+        success?: false
       }
     end
+  end
 
-    it do
-      is_expected.to have_attributes(
-        default_types.merge(types)
-      )
-    end
+  it 'is a subclass' do
+    expect(response).to be_a described_class
   end
 end

--- a/spec/support/shared_examples/momento/response.rb
+++ b/spec/support/shared_examples/momento/response.rb
@@ -1,11 +1,26 @@
 require 'momento/response'
 
 RSpec.shared_examples Momento::Response do
-  let(:response) { described_class.new }
+  let(:response_attributes) do
+    {
+      error?: false
+    }
+  end
 
-  describe '#error?' do
-    it 'is false' do
-      expect(response.error?).to be false
+  describe 'attributes' do
+    it 'has the expected attributes' do
+      expected_attributes = response_attributes
+        .merge(superclass_attributes)
+
+      begin
+        # rubocop:disable Style/RedundantSelf
+        expected_attributes.merge!(self.subclass_attributes)
+        # rubocop:enable Style/RedundantSelf
+      rescue NoMethodError
+        # subclass_attributes might not be defined.
+      end
+
+      expect(response).to have_attributes(**expected_attributes)
     end
   end
 end

--- a/spec/support/shared_examples/momento/set_response.rb
+++ b/spec/support/shared_examples/momento/set_response.rb
@@ -1,24 +1,15 @@
 require 'momento/response'
 
 RSpec.shared_examples Momento::SetResponse do
-  it 'is a subclass' do
-    expect(response).to be_a described_class
-  end
-
-  describe 'type methods' do
-    subject { response }
-
-    let(:default_types) do
+  it_behaves_like Momento::Response do
+    let(:superclass_attributes) do
       {
-        success?: false,
-        error?: false
+        success?: false
       }
     end
+  end
 
-    it do
-      is_expected.to have_attributes(
-        default_types.merge(types)
-      )
-    end
+  it 'is a subclass' do
+    expect(response).to be_a described_class
   end
 end


### PR DESCRIPTION
Removes duplicate code from the individual TypeResponse shared examples. Lets us consistently check Momento::Response behavior.

This will make #6 simpler and the eventual PR easier to review.

Also:
* Make the shared let names more descriptive.
* Make more use of the attribute check.