### PR TITLE
BREAKING CHANGE: Standards & Practices error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ response = client.create_cache("test_cache")
 if response.success? || response.already_exists?
   puts "Created the cache, or it already exists."
 elsif response.error?
-  raise "Couldn't create a cache: #{response}"
+  raise "Couldn't create a cache: #{response.error}"
 else
   raise
 end
@@ -55,7 +55,7 @@ response = client.set("test_cache", "key", "You cached something!")
 if response.success?
   puts "Set an item in the cache."
 elsif response.error?
-  raise "Couldn't set an item in the cache: #{response}"
+  raise "Couldn't set an item in the cache: #{response.error}"
 else
   raise
 end
@@ -67,7 +67,7 @@ if response.hit?
 elsif response.miss?
   puts "The item wasn't found in the cache."
 elsif response.error?
-  raise "Couldn't get an item from the cache: #{response}"
+  raise "Couldn't get an item from the cache: #{response.error}"
 else
   raise
 end

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -17,7 +17,7 @@ response = client.create_cache("test_cache")
 if response.success? || response.already_exists?
   puts "Created the cache, or it already exists."
 elsif response.error?
-  raise "Couldn't create a cache: #{response}"
+  raise "Couldn't create a cache: #{response.error}"
 else
   raise
 end
@@ -27,7 +27,7 @@ response = client.set("test_cache", "key", "You cached something!")
 if response.success?
   puts "Set an item in the cache."
 elsif response.error?
-  raise "Couldn't set an item in the cache: #{response}"
+  raise "Couldn't set an item in the cache: #{response.error}"
 else
   raise
 end
@@ -39,7 +39,7 @@ if response.hit?
 elsif response.miss?
   puts "The item wasn't found in the cache."
 elsif response.error?
-  raise "Couldn't get an item from the cache: #{response}"
+  raise "Couldn't get an item from the cache: #{response.error}"
 else
   raise
 end

--- a/lib/momento/create_cache_response_builder.rb
+++ b/lib/momento/create_cache_response_builder.rb
@@ -17,7 +17,9 @@ module Momento
     rescue GRPC::AlreadyExists
       return CreateCacheResponse::AlreadyExists.new
     rescue GRPC::BadStatus => e
-      CreateCacheResponse::Error.new(exception: e)
+      CreateCacheResponse::Error.new(
+        exception: e, context: context
+      )
     else
       raise TypeError unless response.is_a?(::Momento::ControlClient::CreateCacheResponse)
 

--- a/lib/momento/delete_cache_response_builder.rb
+++ b/lib/momento/delete_cache_response_builder.rb
@@ -15,7 +15,9 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      DeleteCacheResponse::Error.new(exception: e)
+      DeleteCacheResponse::Error.new(
+        exception: e, context: context
+      )
     else
       raise TypeError unless response.is_a?(::Momento::ControlClient::DeleteCacheResponse)
 

--- a/lib/momento/delete_response_builder.rb
+++ b/lib/momento/delete_response_builder.rb
@@ -15,7 +15,7 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      DeleteResponse::Error.new(exception: e)
+      DeleteResponse::Error.new(exception: e, context: context)
     else
       raise TypeError unless response.is_a?(::Momento::CacheClient::DeleteResponse)
 

--- a/lib/momento/error.rb
+++ b/lib/momento/error.rb
@@ -17,10 +17,12 @@ module Momento
       @transport_details = transport_details
     end
 
+    # @return [String]
     def error_code
-      @error_code ||= self.class.name.split('::').last
+      raise NotImplementedEror
     end
 
+    # @return [String]
     def message
       raise NotImplementedEror
     end

--- a/lib/momento/error.rb
+++ b/lib/momento/error.rb
@@ -3,18 +3,18 @@ require_relative 'error/types'
 module Momento
   # Errors from the Momento client or service.
   class Error
-    attr_reader :exception, :context, :transport_metadata, :details
+    attr_reader :exception, :context, :transport_details, :details
 
     def initialize(
       exception:,
       context: {},
-      transport_metadata: nil,
+      transport_details: nil,
       details: nil
     )
       @exception = exception
       @context = context
       @details = details
-      @transport_metadata = transport_metadata
+      @transport_details = transport_details
     end
 
     def error_code

--- a/lib/momento/error.rb
+++ b/lib/momento/error.rb
@@ -19,12 +19,12 @@ module Momento
 
     # @return [String]
     def error_code
-      raise NotImplementedEror
+      raise NotImplementedError
     end
 
     # @return [String]
     def message
-      raise NotImplementedEror
+      raise NotImplementedError
     end
 
     def to_s

--- a/lib/momento/error.rb
+++ b/lib/momento/error.rb
@@ -1,0 +1,32 @@
+require_relative 'error/types'
+
+module Momento
+  # Errors from the Momento client or service.
+  class Error
+    attr_reader :exception, :context, :transport_metadata, :details
+
+    def initialize(
+      exception:,
+      context: {},
+      transport_metadata: nil,
+      details: nil
+    )
+      @exception = exception
+      @context = context
+      @details = details
+      @transport_metadata = transport_metadata
+    end
+
+    def error_code
+      @error_code ||= self.class.name.split('::').last
+    end
+
+    def message
+      raise NotImplementedEror
+    end
+
+    def to_s
+      message
+    end
+  end
+end

--- a/lib/momento/error/grpc_details.rb
+++ b/lib/momento/error/grpc_details.rb
@@ -8,14 +8,17 @@ module Momento
         @grpc = grpc
       end
 
+      # @return [Integer]
       def code
-        grpc.status
+        grpc.code
       end
 
+      # @return [String]
       def details
         grpc.details
       end
 
+      # @return [Hash]
       def metadata
         grpc.metadata
       end

--- a/lib/momento/error/grpc_details.rb
+++ b/lib/momento/error/grpc_details.rb
@@ -1,0 +1,24 @@
+module Momento
+  class Error
+    # Details about a GRPC error.
+    class GrpcDetails
+      attr_reader :grpc
+
+      def initialize(grpc)
+        @grpc = grpc
+      end
+
+      def code
+        grpc.status
+      end
+
+      def details
+        grpc.details
+      end
+
+      def metadata
+        grpc.metadata
+      end
+    end
+  end
+end

--- a/lib/momento/error/transport_details.rb
+++ b/lib/momento/error/transport_details.rb
@@ -1,0 +1,12 @@
+module Momento
+  class Error
+    # A class to capture information specific to a particular transport layer.
+    class TransportDetails
+      attr_reader :grpc
+
+      def initialize(grpc:)
+        @grpc = GrpcDetails.new(grpc)
+      end
+    end
+  end
+end

--- a/lib/momento/error/types.rb
+++ b/lib/momento/error/types.rb
@@ -1,0 +1,112 @@
+module Momento
+  class Error
+    # rubocop:disable Layout/LineLength
+
+    # A cache with the specified name already exists.
+    class AlreadyExistsError < Error
+      def message
+        "A cache with the specified name already exists.  To resolve this error, either delete the existing cache and make a new one, or use a different name.  Cache name: '#{context[:cache_name]}'"
+      end
+    end
+
+    # Invalid authentication credentials to connect to cache service
+    class AuthenticationError < Error
+      def message
+        "Invalid authentication credentials to connect to cache service: #{details}"
+      end
+    end
+
+    # The request was invalid.
+    class BadRequestError < Error
+      def message
+        "The request was invalid; please contact Momento: #{details}"
+      end
+    end
+
+    # The request was cancelled by the server.
+    class CancelledError < Error
+      def message
+        "The request was cancelled by the server; please contact Momento: #{details}"
+      end
+    end
+
+    # A client resource (most likely memory) was exhausted.
+    class ClientResourceExhaustedError < Error
+      def message
+        "A client resource (most likely memory) was exhausted.  If you are executing a high volume of concurrent requests or using very large object sizes, your Configuration may need to be updated to allocate more memory.  Please contact Momento for assistance."
+      end
+    end
+
+    # System is not in a state required for the operation\'s execution
+    class FailedPreconditionError < Error
+      def message
+        "System is not in a state required for the operation's execution"
+      end
+    end
+
+    # An unexpected error occurred while trying to fulfill the request.
+    class InternalServerError < Error
+      def message
+        "An unexpected error occurred while trying to fulfill the request; please contact Momento: #{details}"
+      end
+    end
+
+    # Invalid argument passed to Momento client
+    class InvalidArgumentError < Error
+      def message
+        "Invalid argument passed to Momento client: #{details}"
+      end
+    end
+
+    # Request rate exceeded the limits for this account.
+    class LimitExceededError < Error
+      def message
+        "Request rate exceeded the limits for this account.  To resolve this error, reduce your request rate, or contact Momento to request a limit increase."
+      end
+    end
+
+    # A cache with the specified name does not exist.
+    class NotFoundError < Error
+      def message
+        "A cache with the specified name does not exist.  To resolve this error, make sure you have created the cache before attempting to use it.  Cache name: '#{context[:cache_name]}'"
+      end
+    end
+
+    # Insufficient permissions to perform an operation on a cache.
+    class PermissionError < Error
+      def message
+        "Insufficient permissions to perform an operation on a cache: #{details}"
+      end
+    end
+
+    # The server was unable to handle the request
+    class ServerUnavailableError < Error
+      def message
+        "The server was unable to handle the request; consider retrying.  If the error persists, please contact Momento."
+      end
+    end
+
+    # The client's configured timeout was exceeded.
+    class TimeoutError < Error
+      def message
+        "The client's configured timeout was exceeded; you may need to use a Configuration with more lenient timeouts.  Timeout value: #{context[:timeout]}"
+      end
+    end
+
+    # The cache service failed due to an internal error
+    class UnknownError < Error
+      def message
+        "CacheService failed due to an internal error"
+      end
+    end
+
+    # The cache service failed due to an internal error
+    class UnknownServiceError < Error
+      def message
+        "The service returned an unknown response; please contact Momento: ${details}"
+      end
+    end
+
+    # rubocop:enable Layout/LineLength
+  end
+end

--- a/lib/momento/error/types.rb
+++ b/lib/momento/error/types.rb
@@ -163,7 +163,7 @@ module Momento
       end
 
       def message
-        "The service returned an unknown response; please contact Momento: ${details}"
+        "The service returned an unknown response; please contact Momento: #{details}"
       end
     end
 

--- a/lib/momento/error/types.rb
+++ b/lib/momento/error/types.rb
@@ -4,6 +4,10 @@ module Momento
 
     # A cache with the specified name already exists.
     class AlreadyExistsError < Error
+      def error_code
+        'ALREADY_EXISTS_ERROR'
+      end
+
       def message
         "A cache with the specified name already exists.  To resolve this error, either delete the existing cache and make a new one, or use a different name.  Cache name: '#{context[:cache_name]}'"
       end
@@ -11,6 +15,10 @@ module Momento
 
     # Invalid authentication credentials to connect to cache service
     class AuthenticationError < Error
+      def error_code
+        'AUTHENTICATION_ERROR'
+      end
+
       def message
         "Invalid authentication credentials to connect to cache service: #{details}"
       end
@@ -18,6 +26,10 @@ module Momento
 
     # The request was invalid.
     class BadRequestError < Error
+      def error_code
+        'BAD_REQUEST_ERROR'
+      end
+
       def message
         "The request was invalid; please contact Momento: #{details}"
       end
@@ -25,6 +37,10 @@ module Momento
 
     # The request was cancelled by the server.
     class CancelledError < Error
+      def error_code
+        'CANCELLED_ERROR'
+      end
+
       def message
         "The request was cancelled by the server; please contact Momento: #{details}"
       end
@@ -32,6 +48,10 @@ module Momento
 
     # A client resource (most likely memory) was exhausted.
     class ClientResourceExhaustedError < Error
+      def error_code
+        'CLIENT_RESOURCE_EXHAUSTED'
+      end
+
       def message
         "A client resource (most likely memory) was exhausted.  If you are executing a high volume of concurrent requests or using very large object sizes, your Configuration may need to be updated to allocate more memory.  Please contact Momento for assistance."
       end
@@ -39,6 +59,10 @@ module Momento
 
     # System is not in a state required for the operation\'s execution
     class FailedPreconditionError < Error
+      def error_code
+        'FAILED_PRECONDITION_ERROR'
+      end
+
       def message
         "System is not in a state required for the operation's execution"
       end
@@ -46,6 +70,10 @@ module Momento
 
     # An unexpected error occurred while trying to fulfill the request.
     class InternalServerError < Error
+      def error_code
+        'INTERNAL_SERVER_ERROR'
+      end
+
       def message
         "An unexpected error occurred while trying to fulfill the request; please contact Momento: #{details}"
       end
@@ -53,6 +81,10 @@ module Momento
 
     # Invalid argument passed to Momento client
     class InvalidArgumentError < Error
+      def error_code
+        'INVALID_ARGUMENT_ERROR'
+      end
+
       def message
         "Invalid argument passed to Momento client: #{details}"
       end
@@ -60,6 +92,10 @@ module Momento
 
     # Request rate exceeded the limits for this account.
     class LimitExceededError < Error
+      def error_code
+        'LIMIT_EXCEEDED_ERROR'
+      end
+
       def message
         "Request rate exceeded the limits for this account.  To resolve this error, reduce your request rate, or contact Momento to request a limit increase."
       end
@@ -67,6 +103,10 @@ module Momento
 
     # A cache with the specified name does not exist.
     class NotFoundError < Error
+      def error_code
+        'NOT_FOUND_ERROR'
+      end
+
       def message
         "A cache with the specified name does not exist.  To resolve this error, make sure you have created the cache before attempting to use it.  Cache name: '#{context[:cache_name]}'"
       end
@@ -74,6 +114,10 @@ module Momento
 
     # Insufficient permissions to perform an operation on a cache.
     class PermissionError < Error
+      def error_code
+        'PERMISSION_ERROR'
+      end
+
       def message
         "Insufficient permissions to perform an operation on a cache: #{details}"
       end
@@ -81,6 +125,10 @@ module Momento
 
     # The server was unable to handle the request
     class ServerUnavailableError < Error
+      def error_code
+        'SERVER_UNAVAILABLE'
+      end
+
       def message
         "The server was unable to handle the request; consider retrying.  If the error persists, please contact Momento."
       end
@@ -88,6 +136,10 @@ module Momento
 
     # The client's configured timeout was exceeded.
     class TimeoutError < Error
+      def error_code
+        'TIMEOUT_ERROR'
+      end
+
       def message
         "The client's configured timeout was exceeded; you may need to use a Configuration with more lenient timeouts.  Timeout value: #{context[:timeout]}"
       end
@@ -95,6 +147,10 @@ module Momento
 
     # The cache service failed due to an internal error
     class UnknownError < Error
+      def error_code
+        'UNKNOWN_ERROR'
+      end
+
       def message
         "CacheService failed due to an internal error"
       end
@@ -102,6 +158,10 @@ module Momento
 
     # The cache service failed due to an internal error
     class UnknownServiceError < Error
+      def error_code
+        'UNKNOWN_SERVICE_ERROR'
+      end
+
       def message
         "The service returned an unknown response; please contact Momento: ${details}"
       end

--- a/lib/momento/error/types.rb
+++ b/lib/momento/error/types.rb
@@ -5,7 +5,7 @@ module Momento
     # A cache with the specified name already exists.
     class AlreadyExistsError < Error
       def error_code
-        'ALREADY_EXISTS_ERROR'
+        :ALREADY_EXISTS_ERROR
       end
 
       def message
@@ -16,7 +16,7 @@ module Momento
     # Invalid authentication credentials to connect to cache service
     class AuthenticationError < Error
       def error_code
-        'AUTHENTICATION_ERROR'
+        :AUTHENTICATION_ERROR
       end
 
       def message
@@ -27,7 +27,7 @@ module Momento
     # The request was invalid.
     class BadRequestError < Error
       def error_code
-        'BAD_REQUEST_ERROR'
+        :BAD_REQUEST_ERROR
       end
 
       def message
@@ -38,7 +38,7 @@ module Momento
     # The request was cancelled by the server.
     class CancelledError < Error
       def error_code
-        'CANCELLED_ERROR'
+        :CANCELLED_ERROR
       end
 
       def message
@@ -49,7 +49,7 @@ module Momento
     # A client resource (most likely memory) was exhausted.
     class ClientResourceExhaustedError < Error
       def error_code
-        'CLIENT_RESOURCE_EXHAUSTED'
+        :CLIENT_RESOURCE_EXHAUSTED
       end
 
       def message
@@ -60,7 +60,7 @@ module Momento
     # System is not in a state required for the operation\'s execution
     class FailedPreconditionError < Error
       def error_code
-        'FAILED_PRECONDITION_ERROR'
+        :FAILED_PRECONDITION_ERROR
       end
 
       def message
@@ -71,7 +71,7 @@ module Momento
     # An unexpected error occurred while trying to fulfill the request.
     class InternalServerError < Error
       def error_code
-        'INTERNAL_SERVER_ERROR'
+        :INTERNAL_SERVER_ERROR
       end
 
       def message
@@ -82,7 +82,7 @@ module Momento
     # Invalid argument passed to Momento client
     class InvalidArgumentError < Error
       def error_code
-        'INVALID_ARGUMENT_ERROR'
+        :INVALID_ARGUMENT_ERROR
       end
 
       def message
@@ -93,7 +93,7 @@ module Momento
     # Request rate exceeded the limits for this account.
     class LimitExceededError < Error
       def error_code
-        'LIMIT_EXCEEDED_ERROR'
+        :LIMIT_EXCEEDED_ERROR
       end
 
       def message
@@ -104,7 +104,7 @@ module Momento
     # A cache with the specified name does not exist.
     class NotFoundError < Error
       def error_code
-        'NOT_FOUND_ERROR'
+        :NOT_FOUND_ERROR
       end
 
       def message
@@ -115,7 +115,7 @@ module Momento
     # Insufficient permissions to perform an operation on a cache.
     class PermissionError < Error
       def error_code
-        'PERMISSION_ERROR'
+        :PERMISSION_ERROR
       end
 
       def message
@@ -126,7 +126,7 @@ module Momento
     # The server was unable to handle the request
     class ServerUnavailableError < Error
       def error_code
-        'SERVER_UNAVAILABLE'
+        :SERVER_UNAVAILABLE
       end
 
       def message
@@ -137,7 +137,7 @@ module Momento
     # The client's configured timeout was exceeded.
     class TimeoutError < Error
       def error_code
-        'TIMEOUT_ERROR'
+        :TIMEOUT_ERROR
       end
 
       def message
@@ -148,7 +148,7 @@ module Momento
     # The cache service failed due to an internal error
     class UnknownError < Error
       def error_code
-        'UNKNOWN_ERROR'
+        :UNKNOWN_ERROR
       end
 
       def message
@@ -159,7 +159,7 @@ module Momento
     # The cache service failed due to an internal error
     class UnknownServiceError < Error
       def error_code
-        'UNKNOWN_SERVICE_ERROR'
+        :UNKNOWN_SERVICE_ERROR
       end
 
       def message

--- a/lib/momento/error_builder.rb
+++ b/lib/momento/error_builder.rb
@@ -23,7 +23,8 @@ module Momento
       GRPC::Unknown => Error::UnknownServiceError
     }.freeze
 
-    OTHER_EXCEPTION_MAP = {}.freeze
+    # Default to UnknownError.
+    OTHER_EXCEPTION_MAP = Hash.new(Error::UnknownError).freeze
 
     class << self
       def from_exception(exception, context: {})
@@ -57,17 +58,12 @@ module Momento
     end
 
     def from_other_exception
-      return unless (error_class = OTHER_EXCEPTION_MAP[@exception.class])
+      error_class = OTHER_EXCEPTION_MAP[@exception.class]
 
       return error_class.new(
         context: @context,
-        exception: @exception
-      )
-    end
-
-    def from_unknown_exception
-      return UnknownError.new(
-        exception: @exception, context: @context
+        exception: @exception,
+        details: @exception.message
       )
     end
   end

--- a/lib/momento/error_builder.rb
+++ b/lib/momento/error_builder.rb
@@ -51,7 +51,7 @@ module Momento
       return error_class.new(
         context: @context,
         exception: @exception,
-        transport_metadata: @exception.metadata,
+        transport_details: Error::TransportDetails.new(grpc: @exception),
         details: @exception.details
       )
     end

--- a/lib/momento/error_builder.rb
+++ b/lib/momento/error_builder.rb
@@ -1,0 +1,74 @@
+require 'grpc'
+require_relative 'error/types'
+
+module Momento
+  # An internal class to build Momento::Errors
+  class ErrorBuilder
+    GRPC_EXCEPTION_MAP = {
+      GRPC::Aborted => Error::InternalServerError,
+      GRPC::AlreadyExists => Error::AlreadyExistsError,
+      GRPC::Cancelled => Error::CancelledError,
+      GRPC::DataLoss => Error::InternalServerError,
+      GRPC::DeadlineExceeded => Error::TimeoutError,
+      GRPC::FailedPrecondition => Error::FailedPreconditionError,
+      GRPC::Internal => Error::InternalServerError,
+      GRPC::InvalidArgument => Error::InvalidArgumentError,
+      GRPC::NotFound => Error::NotFoundError,
+      GRPC::OutOfRange => Error::BadRequestError,
+      GRPC::PermissionDenied => Error::PermissionError,
+      GRPC::ResourceExhausted => Error::LimitExceededError,
+      GRPC::Unauthenticated => Error::AuthenticationError,
+      GRPC::Unavailable => Error::ServerUnavailableError,
+      GRPC::Unimplemented => Error::BadRequestError,
+      GRPC::Unknown => Error::UnknownServiceError
+    }.freeze
+
+    OTHER_EXCEPTION_MAP = {}.freeze
+
+    class << self
+      def from_exception(exception, context: {})
+        new(exception: exception, context: context)
+          .from_exception
+      end
+    end
+
+    def initialize(exception:, context:)
+      @exception = exception
+      @context = context
+    end
+
+    def from_exception
+      return from_grpc_exception ||
+             from_other_exception ||
+             from_unknown_exception
+    end
+
+    private
+
+    def from_grpc_exception
+      return unless (error_class = GRPC_EXCEPTION_MAP[@exception.class])
+
+      return error_class.new(
+        context: @context,
+        exception: @exception,
+        transport_metadata: @exception.metadata,
+        details: @exception.details
+      )
+    end
+
+    def from_other_exception
+      return unless (error_class = OTHER_EXCEPTION_MAP[@exception.class])
+
+      return error_class.new(
+        context: @context,
+        exception: @exception
+      )
+    end
+
+    def from_unknown_exception
+      return UnknownError.new(
+        exception: @exception, context: @context
+      )
+    end
+  end
+end

--- a/lib/momento/get_response_builder.rb
+++ b/lib/momento/get_response_builder.rb
@@ -16,7 +16,7 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      GetResponse::Error.new(exception: e)
+      GetResponse::Error.new(exception: e, context: context)
     else
       from_response(response)
     end

--- a/lib/momento/list_caches_response_builder.rb
+++ b/lib/momento/list_caches_response_builder.rb
@@ -15,7 +15,9 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      ListCachesResponse::Error.new(exception: e)
+      ListCachesResponse::Error.new(
+        exception: e, context: context
+      )
     else
       raise TypeError unless response.is_a?(::Momento::ControlClient::ListCachesResponse)
 

--- a/lib/momento/response.rb
+++ b/lib/momento/response.rb
@@ -17,6 +17,14 @@ require_relative 'set_response_builder'
 module Momento
   # A superclass for all Momento responses.
   class Response
+    # Returns the error portion of the response, if any.
+    #
+    # @return [Momento::Response::Error, nil]
+    def error
+      nil
+    end
+
+    # Is the response an error?
     def error?
       false
     end

--- a/lib/momento/response.rb
+++ b/lib/momento/response.rb
@@ -1,6 +1,8 @@
 require 'grpc'
 require_relative 'response/error'
 require_relative 'error'
+require_relative 'error/grpc_details'
+require_relative 'error/transport_details'
 require_relative 'error_builder'
 require_relative 'response_builder'
 require_relative 'create_cache_response'

--- a/lib/momento/response.rb
+++ b/lib/momento/response.rb
@@ -1,5 +1,7 @@
 require 'grpc'
 require_relative 'response/error'
+require_relative 'error'
+require_relative 'error_builder'
 require_relative 'response_builder'
 require_relative 'create_cache_response'
 require_relative 'create_cache_response_builder'
@@ -19,7 +21,7 @@ module Momento
   class Response
     # Returns the error portion of the response, if any.
     #
-    # @return [Momento::Response::Error, nil]
+    # @return [Momento::Error, nil]
     def error
       nil
     end

--- a/lib/momento/response/error.rb
+++ b/lib/momento/response/error.rb
@@ -3,9 +3,13 @@ module Momento
     # A module for responses which contain errors.
     module Error
       attr_reader :exception
+      attr_reader :error
 
       def initialize(exception:, context: {})
         @exception = exception
+        @error = Momento::ErrorBuilder.from_exception(
+          exception, context: context
+        ).freeze
       end
 
       def error?

--- a/lib/momento/response/error.rb
+++ b/lib/momento/response/error.rb
@@ -2,11 +2,9 @@ module Momento
   class Response
     # A module for responses which contain errors.
     module Error
-      attr_reader :exception
       attr_reader :error
 
       def initialize(exception:, context: {})
-        @exception = exception
         @error = Momento::ErrorBuilder.from_exception(
           exception, context: context
         ).freeze

--- a/lib/momento/response/error.rb
+++ b/lib/momento/response/error.rb
@@ -4,7 +4,7 @@ module Momento
     module Error
       attr_reader :exception
 
-      def initialize(exception:)
+      def initialize(exception:, context: {})
         @exception = exception
       end
 

--- a/lib/momento/set_response_builder.rb
+++ b/lib/momento/set_response_builder.rb
@@ -15,7 +15,7 @@ module Momento
     def from_block
       response = yield
     rescue GRPC::BadStatus => e
-      SetResponse::Error.new(exception: e)
+      SetResponse::Error.new(exception: e, context: context)
     else
       raise TypeError unless response.is_a?(::Momento::CacheClient::SetResponse)
 

--- a/lib/momento/simple_cache_client.rb
+++ b/lib/momento/simple_cache_client.rb
@@ -161,7 +161,7 @@ module Momento
 
         loop do
           response = list_caches(next_token: next_token)
-          raise response.exception if response.is_a? Momento::Response::Error
+          raise response.error.exception if response.is_a? Momento::Response::Error
 
           response.cache_names.each do |name|
             yielder << name

--- a/spec/momento/create_cache_response/error_spec.rb
+++ b/spec/momento/create_cache_response/error_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Momento::CreateCacheResponse::Error do
 
   it_behaves_like Momento::CreateCacheResponse do
     let(:subclass_attributes) do
-      { error?: true }
+      {
+        error?: true,
+        error: be_a(Momento::Error)
+      }
     end
   end
 end

--- a/spec/momento/delete_cache_response/error_spec.rb
+++ b/spec/momento/delete_cache_response/error_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Momento::DeleteCacheResponse::Error do
 
   it_behaves_like Momento::DeleteCacheResponse do
     let(:subclass_attributes) do
-      { error?: true }
+      {
+        error?: true,
+        error: be_a(Momento::Error)
+      }
     end
   end
 end

--- a/spec/momento/delete_response/error_spec.rb
+++ b/spec/momento/delete_response/error_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Momento::DeleteResponse::Error do
 
   it_behaves_like Momento::DeleteResponse do
     let(:subclass_attributes) do
-      { error?: true }
+      {
+        error?: true,
+        error: be_a(Momento::Error)
+      }
     end
   end
 end

--- a/spec/momento/error/types_spec.rb
+++ b/spec/momento/error/types_spec.rb
@@ -1,0 +1,148 @@
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'Momento::Error subclasses' do
+  # rubocop:enable RSpec/DescribeClass
+
+  let(:cache_name) { "food and stuff" }
+  let(:timeout) { 123 }
+  # The contexts used by the types.
+  let(:context) do
+    {
+      cache_name: cache_name,
+      timeout: timeout
+    }
+  end
+  let(:details) { "Basset hounds got long ears" }
+  let(:exception) { StandardError.new("the front fell off") }
+  let(:error) {
+    described_class.new(
+      exception: exception,
+      context: context,
+      details: details
+    )
+  }
+
+  shared_examples Momento::Error do
+    describe '#error_code' do
+      it 'has the correct error code' do
+        expect(error.error_code).to eq error_code
+      end
+    end
+
+    describe '#message' do
+      it 'uses context in its message' do
+        expect(error.message).to match(message_re)
+      end
+    end
+
+    describe '#to_s' do
+      it 'uses the message for stringification' do
+        expect(error.to_s).to match(message_re)
+      end
+    end
+  end
+
+  describe Momento::Error::AlreadyExistsError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'ALREADY_EXISTS_ERROR' }
+      let(:message_re) { /Cache name: '#{cache_name}'/ }
+    end
+  end
+
+  describe Momento::Error::AuthenticationError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'AUTHENTICATION_ERROR' }
+      let(:message_re) { /cache service: #{details}/ }
+    end
+  end
+
+  describe Momento::Error::BadRequestError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'BAD_REQUEST_ERROR' }
+      let(:message_re) { /please contact Momento: #{details}/ }
+    end
+  end
+
+  describe Momento::Error::CancelledError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'CANCELLED_ERROR' }
+      let(:message_re) { /please contact Momento: #{details}/ }
+    end
+  end
+
+  describe Momento::Error::ClientResourceExhaustedError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'CLIENT_RESOURCE_EXHAUSTED' }
+      let(:message_re) { /A client resource \(most likely memory\) was exhausted./ }
+    end
+  end
+
+  describe Momento::Error::FailedPreconditionError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'FAILED_PRECONDITION_ERROR' }
+      let(:message_re) { /System is not in a state required for the operation's execution/ }
+    end
+  end
+
+  describe Momento::Error::InternalServerError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'INTERNAL_SERVER_ERROR' }
+      let(:message_re) { /please contact Momento: #{details}/ }
+    end
+  end
+
+  describe Momento::Error::InvalidArgumentError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'INVALID_ARGUMENT_ERROR' }
+      let(:message_re) { /Invalid argument passed to Momento client: #{details}/ }
+    end
+  end
+
+  describe Momento::Error::LimitExceededError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'LIMIT_EXCEEDED_ERROR' }
+      let(:message_re) { /Request rate exceeded the limits for this account/ }
+    end
+  end
+
+  describe Momento::Error::NotFoundError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'NOT_FOUND_ERROR' }
+      let(:message_re) { /Cache name: '#{cache_name}'/ }
+    end
+  end
+
+  describe Momento::Error::PermissionError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'PERMISSION_ERROR' }
+      let(:message_re) { /operation on a cache: #{details}/ }
+    end
+  end
+
+  describe Momento::Error::ServerUnavailableError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'SERVER_UNAVAILABLE' }
+      let(:message_re) { /The server was unable to handle the request/ }
+    end
+  end
+
+  describe Momento::Error::TimeoutError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'TIMEOUT_ERROR' }
+      let(:message_re) { /The client's configured timeout was exceeded/ }
+    end
+  end
+
+  describe Momento::Error::UnknownError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'UNKNOWN_ERROR' }
+      let(:message_re) { /CacheService failed due to an internal error/ }
+    end
+  end
+
+  describe Momento::Error::UnknownServiceError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { 'UNKNOWN_SERVICE_ERROR' }
+      let(:message_re) { /please contact Momento: #{details}/ }
+    end
+  end
+end

--- a/spec/momento/error/types_spec.rb
+++ b/spec/momento/error/types_spec.rb
@@ -43,105 +43,105 @@ RSpec.describe 'Momento::Error subclasses' do
 
   describe Momento::Error::AlreadyExistsError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'ALREADY_EXISTS_ERROR' }
+      let(:error_code) { :ALREADY_EXISTS_ERROR }
       let(:message_re) { /Cache name: '#{cache_name}'/ }
     end
   end
 
   describe Momento::Error::AuthenticationError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'AUTHENTICATION_ERROR' }
+      let(:error_code) { :AUTHENTICATION_ERROR }
       let(:message_re) { /cache service: #{details}/ }
     end
   end
 
   describe Momento::Error::BadRequestError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'BAD_REQUEST_ERROR' }
+      let(:error_code) { :BAD_REQUEST_ERROR }
       let(:message_re) { /please contact Momento: #{details}/ }
     end
   end
 
   describe Momento::Error::CancelledError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'CANCELLED_ERROR' }
+      let(:error_code) { :CANCELLED_ERROR }
       let(:message_re) { /please contact Momento: #{details}/ }
     end
   end
 
   describe Momento::Error::ClientResourceExhaustedError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'CLIENT_RESOURCE_EXHAUSTED' }
+      let(:error_code) { :CLIENT_RESOURCE_EXHAUSTED }
       let(:message_re) { /A client resource \(most likely memory\) was exhausted./ }
     end
   end
 
   describe Momento::Error::FailedPreconditionError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'FAILED_PRECONDITION_ERROR' }
+      let(:error_code) { :FAILED_PRECONDITION_ERROR }
       let(:message_re) { /System is not in a state required for the operation's execution/ }
     end
   end
 
   describe Momento::Error::InternalServerError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'INTERNAL_SERVER_ERROR' }
+      let(:error_code) { :INTERNAL_SERVER_ERROR }
       let(:message_re) { /please contact Momento: #{details}/ }
     end
   end
 
   describe Momento::Error::InvalidArgumentError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'INVALID_ARGUMENT_ERROR' }
+      let(:error_code) { :INVALID_ARGUMENT_ERROR }
       let(:message_re) { /Invalid argument passed to Momento client: #{details}/ }
     end
   end
 
   describe Momento::Error::LimitExceededError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'LIMIT_EXCEEDED_ERROR' }
+      let(:error_code) { :LIMIT_EXCEEDED_ERROR }
       let(:message_re) { /Request rate exceeded the limits for this account/ }
     end
   end
 
   describe Momento::Error::NotFoundError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'NOT_FOUND_ERROR' }
+      let(:error_code) { :NOT_FOUND_ERROR }
       let(:message_re) { /Cache name: '#{cache_name}'/ }
     end
   end
 
   describe Momento::Error::PermissionError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'PERMISSION_ERROR' }
+      let(:error_code) { :PERMISSION_ERROR }
       let(:message_re) { /operation on a cache: #{details}/ }
     end
   end
 
   describe Momento::Error::ServerUnavailableError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'SERVER_UNAVAILABLE' }
+      let(:error_code) { :SERVER_UNAVAILABLE }
       let(:message_re) { /The server was unable to handle the request/ }
     end
   end
 
   describe Momento::Error::TimeoutError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'TIMEOUT_ERROR' }
+      let(:error_code) { :TIMEOUT_ERROR }
       let(:message_re) { /The client's configured timeout was exceeded/ }
     end
   end
 
   describe Momento::Error::UnknownError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'UNKNOWN_ERROR' }
+      let(:error_code) { :UNKNOWN_ERROR }
       let(:message_re) { /CacheService failed due to an internal error/ }
     end
   end
 
   describe Momento::Error::UnknownServiceError do
     it_behaves_like Momento::Error do
-      let(:error_code) { 'UNKNOWN_SERVICE_ERROR' }
+      let(:error_code) { :UNKNOWN_SERVICE_ERROR }
       let(:message_re) { /please contact Momento: #{details}/ }
     end
   end

--- a/spec/momento/error_builder_spec.rb
+++ b/spec/momento/error_builder_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Momento::ErrorBuilder do
+  describe '.from_exception' do
+    subject { described_class.from_exception(exception, context: context) }
+
+    let(:context) do
+      { foo: 'bar' }
+    end
+
+    context 'with no context' do
+      subject { described_class.from_exception(exception) }
+
+      let(:exception) { StandardError.new("The front fell off") }
+
+      it {
+        is_expected.to be_a_momento_error
+          .with_context({})
+          .with_exception(exception)
+      }
+    end
+
+    context 'when given an unknown error' do
+      let(:exception) { StandardError.new("The front fell off") }
+
+      it {
+        is_expected.to be_a_momento_error
+          .with_context(context)
+          .with_exception(exception)
+      }
+    end
+
+    context 'when given a GRPC error' do
+      let(:exception) { GRPC::Aborted.new }
+
+      it {
+        is_expected.to be_a_momento_error
+          .with_context(context)
+          .with_grpc_exception(exception)
+      }
+    end
+  end
+end

--- a/spec/momento/error_spec.rb
+++ b/spec/momento/error_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Momento::Error do
+  let(:error) { described_class.new(exception: exception) }
+  let(:exception) { StandardError.new("the front fell off") }
+
+  describe '#error_code' do
+    it 'is not implemented' do
+      expect { error.error_code }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#message' do
+    it 'is not implemented' do
+      expect { error.message }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/momento/get_response/error_spec.rb
+++ b/spec/momento/get_response/error_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Momento::GetResponse::Error do
 
   it_behaves_like Momento::GetResponse do
     let(:subclass_attributes) do
-      { error?: true }
+      {
+        error?: true,
+        error: be_a(Momento::Error)
+      }
     end
   end
 end

--- a/spec/momento/list_caches_response/error_spec.rb
+++ b/spec/momento/list_caches_response/error_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Momento::ListCachesResponse::Error do
 
   it_behaves_like Momento::ListCachesResponse do
     let(:subclass_attributes) do
-      { error?: true }
+      {
+        error?: true,
+        error: be_a(Momento::Error)
+      }
     end
   end
 end

--- a/spec/momento/set_response/error_spec.rb
+++ b/spec/momento/set_response/error_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Momento::SetResponse::Error do
 
   it_behaves_like Momento::SetResponse do
     let(:subclass_attributes) do
-      { error?: true }
+      {
+        error?: true,
+        error: be_a(Momento::Error)
+      }
     end
   end
 end

--- a/spec/momento/simple_cache_client_spec.rb
+++ b/spec/momento/simple_cache_client_spec.rb
@@ -74,15 +74,19 @@ RSpec.describe Momento::SimpleCacheClient do
 
     context 'when the response is a bad status' do
       let(:grpc_error) { GRPC::InvalidArgument.new }
-      let(:response_class) { Momento::CreateCacheResponse::Error }
 
       before do
         allow(control_stub).to receive(:create_cache)
           .and_raise(grpc_error)
       end
 
-      it 'returns the appropriate Response' do
-        expect(client.create_cache(cache_name)).to be_a response_class
+      it 'returns an error response' do
+        response = client.create_cache(cache_name)
+
+        expect(response.error?).to be true
+        expect(response.error).to be_a_momento_error
+          .with_context({ cache_name: cache_name })
+          .with_grpc_exception(grpc_error)
       end
     end
 
@@ -131,15 +135,19 @@ RSpec.describe Momento::SimpleCacheClient do
 
     context 'when the response is a bad status' do
       let(:grpc_error) { GRPC::NotFound.new }
-      let(:response_class) { Momento::DeleteCacheResponse::Error }
 
       before do
         allow(control_stub).to receive(:delete_cache)
           .and_raise(grpc_error)
       end
 
-      it 'returns the appropriate Response' do
-        expect(client.delete_cache(cache_name)).to be_a response_class
+      it 'returns an error response' do
+        response = client.delete_cache(cache_name)
+
+        expect(response.error?).to be true
+        expect(response.error).to be_a_momento_error
+          .with_context({ cache_name: cache_name })
+          .with_grpc_exception(grpc_error)
       end
     end
 
@@ -195,11 +203,22 @@ RSpec.describe Momento::SimpleCacheClient do
       expect(client.list_caches).to be_a Momento::ListCachesResponse::Success
     end
 
-    it 'returns an error response for a gRPC error' do
-      allow(control_stub).to receive(:list_caches)
-        .and_raise(GRPC::PermissionDenied.new)
+    context 'when the response is a GRPC error' do
+      let(:grpc_error) { GRPC::PermissionDenied.new }
 
-      expect(client.list_caches).to be_a Momento::ListCachesResponse::Error
+      before {
+        allow(control_stub).to receive(:list_caches)
+          .and_raise(grpc_error)
+      }
+
+      it 'returns an error response for a gRPC error' do
+        response = client.list_caches
+
+        expect(response.error?).to be true
+        expect(response.error).to be_a_momento_error
+          .with_context({ next_token: '' })
+          .with_grpc_exception(grpc_error)
+      end
     end
 
     it 'raises on an unknown stub error' do
@@ -341,9 +360,12 @@ RSpec.describe Momento::SimpleCacheClient do
         let(:exception) { GRPC::NotFound.new }
 
         it 'returns the appropriate response' do
-          resp = client.get("name", "key")
-          expect(resp).to be_a(Momento::GetResponse::Error)
-          expect(resp.error.exception).to eq exception
+          response = client.get("name", "key")
+
+          expect(response.error?).to be true
+          expect(response.error).to be_a_momento_error
+            .with_context({ cache_name: "name", key: "key" })
+            .with_grpc_exception(exception)
         end
       end
 
@@ -445,9 +467,14 @@ RSpec.describe Momento::SimpleCacheClient do
         let(:exception) { GRPC::NotFound.new }
 
         it 'returns the appropriate response' do
-          resp = client.set("name", "key", "value")
-          expect(resp).to be_a(Momento::SetResponse::Error)
-          expect(resp.error.exception).to eq exception
+          response = client.set("name", "key", "value", ttl: 123)
+
+          expect(response.error?).to be true
+          expect(response.error).to be_a_momento_error
+            .with_context(
+              { cache_name: "name", key: "key", value: "value", ttl: 123 }
+            )
+            .with_grpc_exception(exception)
         end
       end
 
@@ -526,9 +553,12 @@ RSpec.describe Momento::SimpleCacheClient do
         let(:exception) { GRPC::NotFound.new }
 
         it 'returns the appropriate response' do
-          resp = client.delete("name", "key")
-          expect(resp).to be_a(Momento::DeleteResponse::Error)
-          expect(resp.error.exception).to eq exception
+          response = client.delete("name", "key")
+
+          expect(response.error?).to be true
+          expect(response.error).to be_a_momento_error
+            .with_context({ cache_name: "name", key: "key" })
+            .with_grpc_exception(exception)
         end
       end
 

--- a/spec/momento/simple_cache_client_spec.rb
+++ b/spec/momento/simple_cache_client_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe Momento::SimpleCacheClient do
 
       expect {
         client.caches.to_a
-      }.to raise_error(error_response.exception)
+      }.to raise_error(error_response.error.exception)
     end
 
     it 'when list_caches raises, it raises' do
@@ -341,11 +341,9 @@ RSpec.describe Momento::SimpleCacheClient do
         let(:exception) { GRPC::NotFound.new }
 
         it 'returns the appropriate response' do
-          expect(
-            client.get("name", "key")
-          ).to be_a(Momento::GetResponse::Error).and have_attributes(
-            exception: exception
-          )
+          resp = client.get("name", "key")
+          expect(resp).to be_a(Momento::GetResponse::Error)
+          expect(resp.error.exception).to eq exception
         end
       end
 
@@ -447,11 +445,9 @@ RSpec.describe Momento::SimpleCacheClient do
         let(:exception) { GRPC::NotFound.new }
 
         it 'returns the appropriate response' do
-          expect(
-            client.set("name", "key", "value")
-          ).to be_a(Momento::SetResponse::Error).and have_attributes(
-            exception: exception
-          )
+          resp = client.set("name", "key", "value")
+          expect(resp).to be_a(Momento::SetResponse::Error)
+          expect(resp.error.exception).to eq exception
         end
       end
 
@@ -530,11 +526,9 @@ RSpec.describe Momento::SimpleCacheClient do
         let(:exception) { GRPC::NotFound.new }
 
         it 'returns the appropriate response' do
-          expect(
-            client.delete("name", "key")
-          ).to be_a(Momento::DeleteResponse::Error).and have_attributes(
-            exception: exception
-          )
+          resp = client.delete("name", "key")
+          expect(resp).to be_a(Momento::DeleteResponse::Error)
+          expect(resp.error.exception).to eq exception
         end
       end
 

--- a/spec/support/matchers/be_a_momento_error.rb
+++ b/spec/support/matchers/be_a_momento_error.rb
@@ -4,10 +4,16 @@ RSpec::Matchers.define :be_a_momento_error do
 
     expect(actual).to be_a(Momento::Error)
 
+    details = if @grpc_exception
+                @grpc_exception.details
+              elsif @exception
+                @exception.message
+              end
+
     expect(actual).to have_attributes(
       exception: @exception,
       context: @context,
-      details: @exception&.details
+      details: details
     )
 
     if @grpc_exception
@@ -19,6 +25,8 @@ RSpec::Matchers.define :be_a_momento_error do
         )
       )
     end
+
+    true
   end
 
   chain :with_context do |context|
@@ -28,5 +36,9 @@ RSpec::Matchers.define :be_a_momento_error do
   chain :with_grpc_exception do |exception|
     @exception = exception
     @grpc_exception = exception
+  end
+
+  chain :with_exception do |exception|
+    @exception = exception
   end
 end

--- a/spec/support/matchers/be_a_momento_error.rb
+++ b/spec/support/matchers/be_a_momento_error.rb
@@ -1,0 +1,32 @@
+RSpec::Matchers.define :be_a_momento_error do
+  match(notify_expectation_failures: true) do |actual|
+    @context ||= {}
+
+    expect(actual).to be_a(Momento::Error)
+
+    expect(actual).to have_attributes(
+      exception: @exception,
+      context: @context,
+      details: @exception&.details
+    )
+
+    if @grpc_exception
+      expect(actual.transport_details).to have_attributes(
+        grpc: have_attributes(
+          code: @grpc_exception.code,
+          details: @grpc_exception.details,
+          metadata: @grpc_exception.metadata
+        )
+      )
+    end
+  end
+
+  chain :with_context do |context|
+    @context = context
+  end
+
+  chain :with_grpc_exception do |exception|
+    @exception = exception
+    @grpc_exception = exception
+  end
+end

--- a/spec/support/shared_examples/momento/response.rb
+++ b/spec/support/shared_examples/momento/response.rb
@@ -3,7 +3,8 @@ require 'momento/response'
 RSpec.shared_examples Momento::Response do
   let(:response_attributes) do
     {
-      error?: false
+      error?: false,
+      error: nil
     }
   end
 

--- a/spec/support/shared_examples/momento/response/from_block.rb
+++ b/spec/support/shared_examples/momento/response/from_block.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples 'it wraps gRPC exceptions' do
 
   it 'wraps the exception' do
     expect(
-      described_class.from_block { raise exception }.exception
+      described_class.from_block { raise exception }.error.exception
     ).to eq exception
   end
 

--- a/spec/support/shared_examples/momento/response_builder.rb
+++ b/spec/support/shared_examples/momento/response_builder.rb
@@ -31,7 +31,7 @@ RSpec.shared_examples '#from_block wraps gRPC exceptions' do
 
   it 'wraps the exception' do
     expect(
-      builder.from_block { raise exception }.exception
+      builder.from_block { raise exception }.error.exception
     ).to eq exception
   end
 


### PR DESCRIPTION
Fully implements [Momento Client SDKs Specification: Error Handling](https://github.com/momentohq/standards-and-practices/blob/main/docs/client-specifications/error-handling.md), except "Our response objects are always safely printable" which will be in #27.

- Ruby does't have enums. MomentoErrorCode is implemented as subclasses with an error_code method.
- Momento::Response::Error#exception was removed breaking the v0.1.0 interface.

Closes #6 