### PR TITLE
BREAKING_CHANGE: Consistently stringify responses

### DIFF
--- a/lib/momento/get_response.rb
+++ b/lib/momento/get_response.rb
@@ -37,7 +37,7 @@ module Momento
       end
 
       def to_s
-        "#{self.class}: #{display_value}"
+        "#{super}: #{display_value}"
       end
 
       private

--- a/lib/momento/get_response.rb
+++ b/lib/momento/get_response.rb
@@ -20,6 +20,8 @@ module Momento
 
     # Successfully got an item from the cache.
     class Hit < GetResponse
+      VALUE_DISPLAY_LENGTH = 32
+
       # rubocop:disable Lint/MissingSuper
       def initialize(grpc_response:)
         @grpc_response = grpc_response
@@ -35,7 +37,17 @@ module Momento
       end
 
       def to_s
-        value
+        "#{self.class}: #{display_value}"
+      end
+
+      private
+
+      def display_value
+        if value.length < VALUE_DISPLAY_LENGTH
+          value
+        else
+          "#{value[0, VALUE_DISPLAY_LENGTH]}..."
+        end
       end
     end
 

--- a/lib/momento/get_response.rb
+++ b/lib/momento/get_response.rb
@@ -20,8 +20,6 @@ module Momento
 
     # Successfully got an item from the cache.
     class Hit < GetResponse
-      VALUE_DISPLAY_LENGTH = 32
-
       # rubocop:disable Lint/MissingSuper
       def initialize(grpc_response:)
         @grpc_response = grpc_response
@@ -37,17 +35,7 @@ module Momento
       end
 
       def to_s
-        "#{super}: #{display_value}"
-      end
-
-      private
-
-      def display_value
-        if value.length < VALUE_DISPLAY_LENGTH
-          value
-        else
-          "#{value[0, VALUE_DISPLAY_LENGTH]}..."
-        end
+        "#{super}: #{display_string(value)}"
       end
     end
 

--- a/lib/momento/list_caches_response.rb
+++ b/lib/momento/list_caches_response.rb
@@ -9,6 +9,8 @@ module Momento
 
     # A Momento resposne with a page of caches.
     class Success < ListCachesResponse
+      CACHE_NAMES_TO_DISPLAY = 5
+
       # rubocop:disable Lint/MissingSuper
       def initialize(grpc_response:)
         @grpc_response = grpc_response
@@ -25,6 +27,22 @@ module Momento
 
       def next_token
         @grpc_response.next_token
+      end
+
+      def to_s
+        "#{super}: #{display_cache_names}"
+      end
+
+      private
+
+      def display_cache_names
+        display = cache_names.first(CACHE_NAMES_TO_DISPLAY).join(", ")
+
+        if cache_names.size > CACHE_NAMES_TO_DISPLAY
+          "#{display}, ..."
+        else
+          display
+        end
       end
     end
 

--- a/lib/momento/response.rb
+++ b/lib/momento/response.rb
@@ -32,5 +32,9 @@ module Momento
     def error?
       false
     end
+
+    def to_s
+      self.class.to_s
+    end
   end
 end

--- a/lib/momento/response.rb
+++ b/lib/momento/response.rb
@@ -21,6 +21,8 @@ require_relative 'set_response_builder'
 module Momento
   # A superclass for all Momento responses.
   class Response
+    MAX_STRING_DISPLAY_LENGTH = 32
+
     # Returns the error portion of the response, if any.
     #
     # @return [Momento::Error, nil]
@@ -35,6 +37,14 @@ module Momento
 
     def to_s
       self.class.to_s
+    end
+
+    def display_string(string, max_length: MAX_STRING_DISPLAY_LENGTH)
+      if string.length < max_length
+        string
+      else
+        "#{string[0, max_length]}..."
+      end
     end
   end
 end

--- a/lib/momento/response/error.rb
+++ b/lib/momento/response/error.rb
@@ -13,6 +13,10 @@ module Momento
       def error?
         true
       end
+
+      def to_s
+        "#{super}: #{error.message}"
+      end
     end
   end
 end

--- a/lib/momento/set_response.rb
+++ b/lib/momento/set_response.rb
@@ -9,8 +9,23 @@ module Momento
 
     # The item was set.
     class Success < SetResponse
+      attr_accessor :key, :value
+
+      # rubocop:disable Lint/MissingSuper
+      def initialize(key:, value:)
+        @key = key
+        @value = value
+
+        return
+      end
+      # rubocop:enable Lint/MissingSuper
+
       def success?
         true
+      end
+
+      def to_s
+        "#{super}: '#{display_string(key)}' = '#{display_string(value)}'"
       end
     end
 

--- a/lib/momento/set_response_builder.rb
+++ b/lib/momento/set_response_builder.rb
@@ -19,7 +19,7 @@ module Momento
     else
       raise TypeError unless response.is_a?(::Momento::CacheClient::SetResponse)
 
-      SetResponse::Success.new
+      SetResponse::Success.new(key: context[:key], value: context[:value])
     end
   end
 end

--- a/spec/factories/momento/set_response.rb
+++ b/spec/factories/momento/set_response.rb
@@ -3,6 +3,9 @@ FactoryBot.define do
     :momento_set_response_success,
     class: "Momento::SetResponse::Success"
   ) do
+    key { Faker::Lorem.word }
+    value { Faker::Lorem.sentence }
+
     momento_response
   end
 

--- a/spec/momento/create_cache_response/error_spec.rb
+++ b/spec/momento/create_cache_response/error_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Momento::CreateCacheResponse::Error do
     build(:momento_create_cache_response_error)
   }
 
+  it_behaves_like Momento::Response::Error
+
   it_behaves_like Momento::CreateCacheResponse do
     let(:subclass_attributes) do
       {

--- a/spec/momento/delete_cache_response/error_spec.rb
+++ b/spec/momento/delete_cache_response/error_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Momento::DeleteCacheResponse::Error do
     build(:momento_delete_cache_response_error)
   }
 
+  it_behaves_like Momento::Response::Error
+
   it_behaves_like Momento::DeleteCacheResponse do
     let(:subclass_attributes) do
       {

--- a/spec/momento/delete_response/error_spec.rb
+++ b/spec/momento/delete_response/error_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Momento::DeleteResponse::Error do
     build(:momento_delete_response_error)
   }
 
+  it_behaves_like Momento::Response::Error
+
   it_behaves_like Momento::DeleteResponse do
     let(:subclass_attributes) do
       {

--- a/spec/momento/get_response/error_spec.rb
+++ b/spec/momento/get_response/error_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Momento::GetResponse::Error do
     build(:momento_get_response_error)
   }
 
+  it_behaves_like Momento::Response::Error
+
   it_behaves_like Momento::GetResponse do
     let(:subclass_attributes) do
       {

--- a/spec/momento/get_response/hit_spec.rb
+++ b/spec/momento/get_response/hit_spec.rb
@@ -12,9 +12,35 @@ RSpec.describe Momento::GetResponse::Hit do
     let(:subclass_attributes) do
       {
         hit?: true,
-        value: grpc_response.cache_body,
-        to_s: response.value
+        value: grpc_response.cache_body
       }
+    end
+  end
+
+  describe '#to_s' do
+    subject { response.to_s }
+
+    let(:response) {
+      build(:momento_get_response_hit, value: value)
+    }
+
+    context 'when the vaule is short' do
+      let(:value) { "short" }
+
+      it { is_expected.to match(/short/) }
+    end
+
+    context 'when the value is long' do
+      let(:value) {
+        v = <<-VALUE
+        Lopado­temacho­selacho­galeo­kranio­leipsano­drim­hypo­trimmato­silphio­karabo­melito­katakechy­meno­kichl­epi­kossypho­phatto­perister­alektryon­opte­kephallio­kigklo­peleio­lagoio­siraio­baphe­tragano­pterygon
+        VALUE
+
+        # This is going directly to the GRPC response which requires ASCII 8Bit.
+        v.force_encoding(Encoding::ASCII_8BIT)
+      }
+
+      it { is_expected.to include("...") }
     end
   end
 end

--- a/spec/momento/list_caches_response/error_spec.rb
+++ b/spec/momento/list_caches_response/error_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Momento::ListCachesResponse::Error do
     build(:momento_list_caches_response_error)
   }
 
+  it_behaves_like Momento::Response::Error
+
   it_behaves_like Momento::ListCachesResponse do
     let(:subclass_attributes) do
       {

--- a/spec/momento/list_caches_response/success_spec.rb
+++ b/spec/momento/list_caches_response/success_spec.rb
@@ -23,4 +23,35 @@ RSpec.describe Momento::ListCachesResponse::Success do
       }
     end
   end
+
+  describe '#to_s' do
+    subject { response.to_s }
+
+    let(:displayed_names) {
+      cache_names.first(
+        described_class.const_get(:CACHE_NAMES_TO_DISPLAY)
+      )
+    }
+
+    context 'when there are few caches' do
+      let(:cache_names) { ["foo", "bar"] }
+
+      it { is_expected.to include cache_names.join(", ") }
+    end
+
+    context 'when there are many caches' do
+      let(:cache_names) {
+        [
+          "secrets", "top secret", "double top secret",
+          "a garden shed at the country club",
+          "dragon hoard", "under the mattress",
+          "on the Moon", "on the secret Moon"
+        ]
+      }
+
+      it {
+        is_expected.to include(", ...").and include(*displayed_names)
+      }
+    end
+  end
 end

--- a/spec/momento/set_response/error_spec.rb
+++ b/spec/momento/set_response/error_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Momento::SetResponse::Error do
     build(:momento_set_response_error)
   }
 
+  it_behaves_like Momento::Response::Error
+
   it_behaves_like Momento::SetResponse do
     let(:subclass_attributes) do
       {

--- a/spec/momento/set_response/success_spec.rb
+++ b/spec/momento/set_response/success_spec.rb
@@ -7,7 +7,43 @@ RSpec.describe Momento::SetResponse::Success do
 
   it_behaves_like Momento::SetResponse do
     let(:subclass_attributes) do
-      { success?: true }
+      {
+        success?: true
+      }
+    end
+  end
+
+  describe '#to_s' do
+    subject { response.to_s }
+
+    let(:response) {
+      build(:momento_set_response_success, key: key, value: value)
+    }
+
+    context 'when the key and value are short' do
+      let(:key) { "foo" }
+      let(:value) { "bar" }
+
+      it {
+        is_expected.to include(response.key).and include(response.value)
+      }
+    end
+
+    context 'when the key and value are long' do
+      let(:key) {
+        "This one time I ate so many Cheetos that my fingers turned orange for, like, a week."
+      }
+      let(:value) {
+        <<-VALUE
+        This is the string that never ends. It just goes on and on my friends. Somebody started typing without knowing what it was.
+        VALUE
+      }
+
+      it {
+        is_expected.to include(response.key[0, 10])
+          .and include(response.value[0, 10])
+          .and include("...")
+      }
     end
   end
 end

--- a/spec/momento/set_response_builder_spec.rb
+++ b/spec/momento/set_response_builder_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe Momento::SetResponseBuilder do
       }
 
       it_behaves_like '#from_block wraps gRPC responses'
+
+      it 'passes the key and value from context' do
+        builder.context = { key: "key", value: "value" }
+
+        momento_response = builder.from_block { response }
+        expect(momento_response).to have_attributes(key: "key", value: "value")
+      end
     end
   end
 end

--- a/spec/support/shared_examples/momento/response.rb
+++ b/spec/support/shared_examples/momento/response.rb
@@ -24,4 +24,10 @@ RSpec.shared_examples Momento::Response do
       expect(response).to have_attributes(**expected_attributes)
     end
   end
+
+  describe '#to_s' do
+    it 'starts with the class' do
+      expect(response.to_s).to start_with(response.class.to_s)
+    end
+  end
 end

--- a/spec/support/shared_examples/momento/response/error.rb
+++ b/spec/support/shared_examples/momento/response/error.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples Momento::Response::Error do
+  describe '#to_s' do
+    it 'contains the error message' do
+      expect(response.to_s).to include(response.error.message)
+    end
+  end
+end


### PR DESCRIPTION
I took the behavior from the PHP client.

The breaking change is previously a Hit would stringify to the complete value.

Closes #27 