### PR TITLE
Handle invalid keys, values, and cache names.

### DIFF
--- a/lib/momento/create_cache_response_builder.rb
+++ b/lib/momento/create_cache_response_builder.rb
@@ -16,7 +16,7 @@ module Momento
       response = yield
     rescue GRPC::AlreadyExists
       return CreateCacheResponse::AlreadyExists.new
-    rescue GRPC::BadStatus => e
+    rescue *RESCUED_EXCEPTIONS => e
       CreateCacheResponse::Error.new(
         exception: e, context: context
       )

--- a/lib/momento/delete_cache_response_builder.rb
+++ b/lib/momento/delete_cache_response_builder.rb
@@ -14,7 +14,7 @@ module Momento
     # @raise [TypeError] when the response is not recognized.
     def from_block
       response = yield
-    rescue GRPC::BadStatus => e
+    rescue *RESCUED_EXCEPTIONS => e
       DeleteCacheResponse::Error.new(
         exception: e, context: context
       )

--- a/lib/momento/delete_response_builder.rb
+++ b/lib/momento/delete_response_builder.rb
@@ -14,7 +14,7 @@ module Momento
     # @raise [TypeError] when the response is not recognized.
     def from_block
       response = yield
-    rescue GRPC::BadStatus => e
+    rescue *RESCUED_EXCEPTIONS => e
       DeleteResponse::Error.new(exception: e, context: context)
     else
       raise TypeError unless response.is_a?(::Momento::CacheClient::DeleteResponse)

--- a/lib/momento/error_builder.rb
+++ b/lib/momento/error_builder.rb
@@ -1,5 +1,6 @@
 require 'grpc'
 require_relative 'error/types'
+require_relative 'exceptions'
 
 module Momento
   # An internal class to build Momento::Errors
@@ -23,8 +24,9 @@ module Momento
       GRPC::Unknown => Error::UnknownServiceError
     }.freeze
 
-    # Default to UnknownError.
-    OTHER_EXCEPTION_MAP = Hash.new(Error::UnknownError).freeze
+    OTHER_EXCEPTION_MAP = {
+      Momento::CacheNameError => Error::InvalidArgumentError
+    }.freeze
 
     class << self
       def from_exception(exception, context: {})
@@ -58,7 +60,7 @@ module Momento
     end
 
     def from_other_exception
-      error_class = OTHER_EXCEPTION_MAP[@exception.class]
+      error_class = OTHER_EXCEPTION_MAP[@exception.class] || Error::UnknownError
 
       return error_class.new(
         context: @context,

--- a/lib/momento/exceptions.rb
+++ b/lib/momento/exceptions.rb
@@ -1,0 +1,4 @@
+module Momento
+  class CacheNameError < ::ArgumentError
+  end
+end

--- a/lib/momento/get_response_builder.rb
+++ b/lib/momento/get_response_builder.rb
@@ -15,7 +15,7 @@ module Momento
     # @raise [TypeError] when the response is not recognized.
     def from_block
       response = yield
-    rescue GRPC::BadStatus => e
+    rescue *RESCUED_EXCEPTIONS => e
       GetResponse::Error.new(exception: e, context: context)
     else
       from_response(response)

--- a/lib/momento/response_builder.rb
+++ b/lib/momento/response_builder.rb
@@ -5,6 +5,10 @@ module Momento
   class ResponseBuilder
     attr_accessor :context
 
+    RESCUED_EXCEPTIONS = [
+      GRPC::BadStatus, *ErrorBuilder::OTHER_EXCEPTION_MAP.keys
+    ].freeze
+
     def initialize(context: {})
       @context = context
     end

--- a/lib/momento/set_response_builder.rb
+++ b/lib/momento/set_response_builder.rb
@@ -14,7 +14,7 @@ module Momento
     # @raise [TypeError] when the response is not recognized.
     def from_block
       response = yield
-    rescue GRPC::BadStatus => e
+    rescue *RESCUED_EXCEPTIONS => e
       SetResponse::Error.new(exception: e, context: context)
     else
       raise TypeError unless response.is_a?(::Momento::CacheClient::SetResponse)

--- a/lib/momento/simple_cache_client.rb
+++ b/lib/momento/simple_cache_client.rb
@@ -34,7 +34,7 @@ module Momento
 
     # @param auth_token [String] the JWT for your Momento account
     # @param default_ttl [Numeric] time-to-live, in seconds
-    # @raise [ArgumentError] if the default_ttl is invalid
+    # @raise [ArgumentError] if the default_ttl or auth_token is invalid
     def initialize(auth_token:, default_ttl:)
       @auth_token = auth_token
       @default_ttl = Momento::Ttl.to_ttl(default_ttl)
@@ -212,6 +212,8 @@ module Momento
 
       @control_endpoint = claim["cp"]
       @cache_endpoint = claim["c"]
+    rescue JWT::DecodeError
+      raise ArgumentError, "Invalid Momento auth token."
     end
 
     def make_combined_credentials

--- a/lib/momento/simple_cache_client.rb
+++ b/lib/momento/simple_cache_client.rb
@@ -47,6 +47,7 @@ module Momento
     # @param cache_name [String]
     # @param key [String] must only contain ASCII characters
     # @return [Momento::GetResponse]
+    # @raise [TypeError] when the key is not a String
     def get(cache_name, key)
       builder = GetResponseBuilder.new(
         context: { cache_name: cache_name, key: key }
@@ -70,6 +71,7 @@ module Momento
     # @param ttl [Numeric] time-to-live, in seconds.
     # @raise [ArgumentError] if the ttl is invalid
     # @return [Momento::SetResponse]
+    # @raise [TypeError] when the key or value is not a String
     def set(cache_name, key, value, ttl: default_ttl)
       ttl = Momento::Ttl.to_ttl(ttl)
 
@@ -93,6 +95,7 @@ module Momento
     # @param cache_name [String]
     # @param key [String] must only contain ASCII characters
     # @return [Momento::DeleteResponse]
+    # @raise [TypeError] when the key or value is not a String
     def delete(cache_name, key)
       builder = DeleteResponseBuilder.new(
         context: { cache_name: cache_name, key: key }
@@ -223,7 +226,10 @@ module Momento
     #
     # @param string [String] the string to make safe for GRPC bytes
     # @return [String] a duplicate safe to use as GRPC bytes
+    # @raise [TypeError] when the string is not a String
     def to_bytes(string)
+      raise TypeError, "expected a String, got a #{string.class}" unless string.is_a?(String)
+
       # dup in case the value is frozen and to avoid changing the value's encoding
       # for the caller.
       return string.dup.force_encoding(Encoding::ASCII_8BIT)

--- a/lib/momento/simple_cache_client.rb
+++ b/lib/momento/simple_cache_client.rb
@@ -49,6 +49,8 @@ module Momento
     # @return [Momento::GetResponse]
     # @raise [TypeError] when the key is not a String
     def get(cache_name, key)
+      validate_cache_name(cache_name)
+
       builder = GetResponseBuilder.new(
         context: { cache_name: cache_name, key: key }
       )
@@ -74,6 +76,7 @@ module Momento
     # @raise [TypeError] when the key or value is not a String
     def set(cache_name, key, value, ttl: default_ttl)
       ttl = Momento::Ttl.to_ttl(ttl)
+      validate_cache_name(cache_name)
 
       builder = SetResponseBuilder.new(
         context: { cache_name: cache_name, key: key, value: value, ttl: ttl }
@@ -97,6 +100,8 @@ module Momento
     # @return [Momento::DeleteResponse]
     # @raise [TypeError] when the key or value is not a String
     def delete(cache_name, key)
+      validate_cache_name(cache_name)
+
       builder = DeleteResponseBuilder.new(
         context: { cache_name: cache_name, key: key }
       )
@@ -114,6 +119,8 @@ module Momento
     # @param cache_name [String] the name of the cache to create.
     # @return [Momento::CreateCacheResponse] the response from Momento.
     def create_cache(cache_name)
+      validate_cache_name(cache_name)
+
       builder = CreateCacheResponseBuilder.new(
         context: { cache_name: cache_name }
       )
@@ -130,6 +137,8 @@ module Momento
     # @param cache_name [String] the name of the cache to delete.
     # @return [Momento::DeleteCacheResponse] the response from Momento.
     def delete_cache(cache_name)
+      validate_cache_name(cache_name)
+
       builder = DeleteCacheResponseBuilder.new(
         context: { cache_name: cache_name }
       )
@@ -233,6 +242,14 @@ module Momento
       # dup in case the value is frozen and to avoid changing the value's encoding
       # for the caller.
       return string.dup.force_encoding(Encoding::ASCII_8BIT)
+    end
+
+    # @param name [String] the cache name to validate
+    # @raise [TypeError] when the name is not a String
+    def validate_cache_name(name)
+      raise TypeError, "Cache name must be a String, got a #{name.class}" unless name.is_a?(String)
+
+      return
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/spec/live_spec.rb
+++ b/spec/live_spec.rb
@@ -188,9 +188,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
     end
 
     it_behaves_like 'it handles server failures'
-    skip "Invalid cache name handling is inconsistent" do
-      it_behaves_like 'it handles invalid cache names'
-    end
+    it_behaves_like 'it handles invalid cache names'
   end
 
   describe '#get' do
@@ -225,9 +223,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
     end
 
     it_behaves_like 'it handles server failures'
-    skip "Invalid cache name handling is inconsistent" do
-      it_behaves_like 'it handles invalid cache names'
-    end
+    it_behaves_like 'it handles invalid cache names'
   end
 
   describe '#set' do
@@ -313,9 +309,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
     end
 
     it_behaves_like 'it handles server failures'
-    skip "Invalid cache name handling is inconsistent" do
-      it_behaves_like 'it handles invalid cache names'
-    end
+    it_behaves_like 'it handles invalid cache names'
   end
 
   describe '#delete' do
@@ -356,8 +350,6 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
     end
 
     it_behaves_like 'it handles server failures'
-    skip "Invalid cache name handling is inconsistent" do
-      it_behaves_like 'it handles invalid cache names'
-    end
+    it_behaves_like 'it handles invalid cache names'
   end
 end

--- a/spec/momento/simple_cache_client_spec.rb
+++ b/spec/momento/simple_cache_client_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe Momento::SimpleCacheClient do
         expect { subject }.to raise_error(ArgumentError, /is not Numeric/)
       }
     end
+
+    context 'with an invalid JWT' do
+      let(:invalid_token) { "let me iiiin!" }
+
+      let(:client) {
+        build(:momento_simple_cache_client, auth_token: invalid_token)
+      }
+
+      it 'raises a ArgumentError' do
+        expect {
+          subject
+        }.to raise_error(
+          an_instance_of(ArgumentError).and(have_attributes(cause: JWT::DecodeError))
+        )
+      end
+    end
   end
 
   shared_examples 'a gRPC stub' do

--- a/spec/momento/simple_cache_client_spec.rb
+++ b/spec/momento/simple_cache_client_spec.rb
@@ -103,6 +103,19 @@ RSpec.describe Momento::SimpleCacheClient do
         }.to raise_error(TypeError, /Cache name must be a String, got a Integer/)
       }
     end
+
+    context 'with a non-ASCII cache name' do
+      let(:cache_name) { "caché" }
+
+      it {
+        is_expected.to have_attributes(
+          error?: true,
+          error: have_attributes(
+            error_code: :INVALID_ARGUMENT_ERROR
+          )
+        )
+      }
+    end
   end
 
   describe '#cache_stub' do

--- a/spec/momento/simple_cache_client_spec.rb
+++ b/spec/momento/simple_cache_client_spec.rb
@@ -83,6 +83,28 @@ RSpec.describe Momento::SimpleCacheClient do
     end
   end
 
+  shared_examples 'it validates the cache name' do
+    context 'when the cache_name is nil' do
+      let(:cache_name) { nil }
+
+      it {
+        expect {
+          subject
+        }.to raise_error(TypeError, /Cache name must be a String, got a NilClass/)
+      }
+    end
+
+    context 'when the cache_name is not a String' do
+      let(:cache_name) { 42 }
+
+      it {
+        expect {
+          subject
+        }.to raise_error(TypeError, /Cache name must be a String, got a Integer/)
+      }
+    end
+  end
+
   describe '#cache_stub' do
     let(:stub_class) { described_class.const_get(:CACHE_CLIENT_STUB_CLASS) }
     let(:stub_method) { :cache_stub }
@@ -103,6 +125,8 @@ RSpec.describe Momento::SimpleCacheClient do
     subject { client.create_cache(cache_name) }
 
     let(:cache_name) { Faker::Lorem.word }
+
+    it_behaves_like 'it validates the cache name'
 
     it 'sends a CreateCacheRequest with the cache name' do
       allow(control_stub).to receive(:create_cache)
@@ -166,6 +190,8 @@ RSpec.describe Momento::SimpleCacheClient do
     subject { client.delete_cache(cache_name) }
 
     let(:cache_name) { Faker::Lorem.word }
+
+    it_behaves_like 'it validates the cache name'
 
     it 'sends a DeleteCacheRequest with the cache name' do
       allow(control_stub).to receive(:delete_cache)
@@ -348,6 +374,7 @@ RSpec.describe Momento::SimpleCacheClient do
     let(:key) { Faker::Lorem.word }
 
     it_behaves_like 'it validates the key'
+    it_behaves_like 'it validates the cache name'
 
     it 'sends a GetRequest with the cache name and key' do
       allow(cache_stub).to receive(:get)
@@ -462,6 +489,7 @@ RSpec.describe Momento::SimpleCacheClient do
 
     it_behaves_like 'it validates the key'
     it_behaves_like 'it validates the value'
+    it_behaves_like 'it validates the cache name'
 
     shared_examples 'it sends a SetRequest' do
       it 'sends a SetRequest with the cache name, key, value, and ttl' do
@@ -590,6 +618,7 @@ RSpec.describe Momento::SimpleCacheClient do
     let(:cache_name) { Faker::Lorem.word }
     let(:key) { Faker::Lorem.word }
 
+    it_behaves_like 'it validates the cache name'
     it_behaves_like 'it validates the key'
 
     it 'sends a DeleteRequest with the cache name and key' do

--- a/spec/momento/simple_cache_client_spec.rb
+++ b/spec/momento/simple_cache_client_spec.rb
@@ -39,6 +39,50 @@ RSpec.describe Momento::SimpleCacheClient do
     end
   end
 
+  shared_examples 'it validates the key' do
+    context 'with a non-String key' do
+      let(:key) { 42 }
+
+      it 'raises TypeError' do
+        expect {
+          subject
+        }.to raise_error(TypeError, /expected a String, got a Integer/)
+      end
+    end
+
+    context 'when a nil key' do
+      let(:key) { nil }
+
+      it 'raises TypeError' do
+        expect {
+          subject
+        }.to raise_error(TypeError, /expected a String, got a NilClass/)
+      end
+    end
+  end
+
+  shared_examples 'it validates the value' do
+    context 'with a non-String value' do
+      let(:value) { 42 }
+
+      it 'raises TypeError' do
+        expect {
+          subject
+        }.to raise_error(TypeError, /expected a String, got a Integer/)
+      end
+    end
+
+    context 'when a nil value' do
+      let(:value) { nil }
+
+      it 'raises TypeError' do
+        expect {
+          subject
+        }.to raise_error(TypeError, /expected a String, got a NilClass/)
+      end
+    end
+  end
+
   describe '#cache_stub' do
     let(:stub_class) { described_class.const_get(:CACHE_CLIENT_STUB_CLASS) }
     let(:stub_method) { :cache_stub }
@@ -303,6 +347,8 @@ RSpec.describe Momento::SimpleCacheClient do
     let(:cache_name) { Faker::Lorem.word }
     let(:key) { Faker::Lorem.word }
 
+    it_behaves_like 'it validates the key'
+
     it 'sends a GetRequest with the cache name and key' do
       allow(cache_stub).to receive(:get)
         .and_return(build(:momento_cache_client_get_response, :hit))
@@ -413,6 +459,9 @@ RSpec.describe Momento::SimpleCacheClient do
     let(:key) { Faker::Lorem.word }
     let(:value) { Faker::Lorem.paragraph }
     let(:ttl) { 1234 }
+
+    it_behaves_like 'it validates the key'
+    it_behaves_like 'it validates the value'
 
     shared_examples 'it sends a SetRequest' do
       it 'sends a SetRequest with the cache name, key, value, and ttl' do
@@ -540,6 +589,8 @@ RSpec.describe Momento::SimpleCacheClient do
 
     let(:cache_name) { Faker::Lorem.word }
     let(:key) { Faker::Lorem.word }
+
+    it_behaves_like 'it validates the key'
 
     it 'sends a DeleteRequest with the cache name and key' do
       allow(cache_stub).to receive(:delete)


### PR DESCRIPTION
- nil and non-String keys, values, and cache names as TypeErrors.
- Non-ASCII cache names are an InvalidArgument response.

There is a broad refactoring of `spec/momento/simple_cache_client_spec.rb` to make it easier to test the validation consistently. It might be easier to review this as individual commits.

Closes #41 
Closes #37 
Closes #66 
Closes #34