### PR TITLE
BREAKING_CHANGE: Split GetResponse::Hit.value into value_bytes and value_string

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ end
 # And get it back.
 response = client.get("test_cache", "key")
 if response.hit?
-  puts "Cache returned: #{response.value}"
+  puts "Cache returned: #{response.value_string}"
 elsif response.miss?
   puts "The item wasn't found in the cache."
 elsif response.error?

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -35,7 +35,7 @@ end
 # And get it back.
 response = client.get("test_cache", "key")
 if response.hit?
-  puts "Cache returned: #{response.value}"
+  puts "Cache returned: #{response.value_string}"
 elsif response.miss?
   puts "The item wasn't found in the cache."
 elsif response.error?

--- a/lib/momento/get_response.rb
+++ b/lib/momento/get_response.rb
@@ -13,8 +13,18 @@ module Momento
       false
     end
 
-    # @return [String,nil] the gotten value, if any.
-    def value
+    # The gotten value, if any, as binary data: an ASCII_8BIT encoded frozen String.
+    #
+    # @return [String,nil] the value, if any, frozen and ASCII_8BIT encoded
+    def value_bytes
+      nil
+    end
+
+    # The gotten value, if any, as a string using your default encoding or specified one.
+    #
+    # @param encoding [Encoding] defaults to Encoding.default_external
+    # @return [String,nil] the value, if any, re-encoded
+    def value_string
       nil
     end
 
@@ -30,12 +40,16 @@ module Momento
         true
       end
 
-      def value
+      def value_bytes
         @grpc_response.cache_body
       end
 
+      def value_string(encoding = Encoding.default_external)
+        value_bytes.dup.force_encoding(encoding)
+      end
+
       def to_s
-        "#{super}: #{display_string(value)}"
+        "#{super}: #{display_string(value_string)}"
       end
     end
 

--- a/spec/live_spec.rb
+++ b/spec/live_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
       miss?: false,
       error?: false,
       error: nil,
-      value: value
+      value_string: value
     )
 
     expect(
@@ -139,7 +139,8 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
       miss?: true,
       error?: false,
       error: nil,
-      value: nil
+      value_string: nil,
+      value_bytes: nil
     )
 
     expect(
@@ -202,7 +203,8 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
         miss?: true,
         error?: false,
         error: nil,
-        value: nil
+        value_string: nil,
+        value_bytes: nil
       )
     end
 
@@ -217,7 +219,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
           miss?: false,
           error?: false,
           error: nil,
-          value: value
+          value_string: value
         )
       end
     end
@@ -242,7 +244,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
         client.get(cache_name, key)
       ).to have_attributes(
         hit?: true,
-        value: value
+        value_string: value
       )
 
       # Short duration TTLs are not accurate.
@@ -267,7 +269,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
           client.get(cache_name, key)
         ).to have_attributes(
           hit?: true,
-          value: value.force_encoding(Encoding::ASCII_8BIT)
+          value_string: value
         )
       end
     end
@@ -286,7 +288,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
           client.get(cache_name, key)
         ).to have_attributes(
           hit?: true,
-          value: value
+          value_bytes: value
         )
       end
     end
@@ -303,7 +305,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
           client.get(cache_name, key)
         ).to have_attributes(
           hit?: true,
-          value: value
+          value_string: value
         )
       end
     end

--- a/spec/momento/get_response/hit_spec.rb
+++ b/spec/momento/get_response/hit_spec.rb
@@ -12,8 +12,37 @@ RSpec.describe Momento::GetResponse::Hit do
     let(:subclass_attributes) do
       {
         hit?: true,
-        value: grpc_response.cache_body
+        value_string: grpc_response.cache_body,
+        value_bytes: grpc_response.cache_body
       }
+    end
+  end
+
+  describe '#value_bytes' do
+    subject { response.value_bytes }
+
+    it {
+      is_expected.to have_attributes(
+        frozen?: true,
+        encoding: Encoding::ASCII_8BIT
+      )
+    }
+  end
+
+  describe '#value_string' do
+    subject { response.value_string }
+
+    it {
+      is_expected.to have_attributes(
+        frozen?: false,
+        encoding: Encoding::UTF_8
+      )
+    }
+
+    it 'will accept a different encoding' do
+      expect(
+        response.value_string(Encoding::Big5)
+      ).to have_attributes(encoding: Encoding::Big5)
     end
   end
 

--- a/spec/momento/get_response_builder_spec.rb
+++ b/spec/momento/get_response_builder_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Momento::GetResponseBuilder do
           builder.from_block { grpc_response }
         ).to be_a(Momento::GetResponse::Hit)
           .and have_attributes(
-            value: grpc_response.cache_body
+            value_string: grpc_response.cache_body
           )
       end
     end

--- a/spec/momento/simple_cache_client_spec.rb
+++ b/spec/momento/simple_cache_client_spec.rb
@@ -461,7 +461,7 @@ RSpec.describe Momento::SimpleCacheClient do
           expect(
             subject
           ).to be_a(Momento::GetResponse::Hit).and have_attributes(
-            value: grpc_response.cache_body
+            value_string: grpc_response.cache_body
           )
         end
       end

--- a/spec/support/shared_examples/momento/get_response.rb
+++ b/spec/support/shared_examples/momento/get_response.rb
@@ -5,7 +5,9 @@ RSpec.shared_examples Momento::GetResponse do
     let(:superclass_attributes) do
       {
         hit?: false,
-        miss?: false
+        miss?: false,
+        value_bytes: nil,
+        value_string: nil
       }
     end
   end


### PR DESCRIPTION
Nobody likes messing with string encoding. Rather than explain it and risk bugs and frustration, just do it for the user. The PHP client does the same thing.

Closes #82 