### PR TITLE
fix: Referring to a method that does not exist.

### DIFF
--- a/lib/momento/error_builder.rb
+++ b/lib/momento/error_builder.rb
@@ -42,8 +42,7 @@ module Momento
 
     def from_exception
       return from_grpc_exception ||
-             from_other_exception ||
-             from_unknown_exception
+             from_other_exception
     end
 
     private


### PR DESCRIPTION
It used to exist, not anymore.