### PR TITLE
feat: add a CredentialProvider

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     momento (0.3.0)
       grpc (~> 1.58)
-      jwt (~> 2)
 
 GEM
   remote: https://rubygems.org/
@@ -104,6 +103,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux
@@ -112,6 +112,7 @@ DEPENDENCIES
   bundler (~> 2.3)
   factory_bot (~> 6.2.1)
   faker (~> 3.0)
+  jwt (~> 2)
   momento!
   pry-byebug (~> 3)
   rake (~> 13.0)

--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ If you're using an M1 or M2 Mac, you may have trouble installing the `grpc` gem;
 
 require 'momento'
 
-# Get your Momento token from an environment variable.
-TOKEN = ENV.fetch('MOMENTO_API_KEY')
-
 # Cached items will be deleted after 12.5 seconds.
 TTL_SECONDS = 12.5
 
 # The name of the cache to create *and delete*
 CACHE_NAME = ENV.fetch('MOMENTO_CACHE_NAME')
 
+# Create a credential provider that loads a Momento API Key from an environment variable.
+credential_provider = Momento::CredentialProvider.from_env_var('MOMENTO_API_KEY')
+
 # Instantiate a Momento client.
 client = Momento::SimpleCacheClient.new(
-  auth_token: TOKEN,
+  credential_provider: credential_provider,
   default_ttl: TTL_SECONDS
 )
 

--- a/examples/compact.rb
+++ b/examples/compact.rb
@@ -2,18 +2,18 @@
 
 require 'momento'
 
-# Get your Momento token from an environment variable.
-TOKEN = ENV.fetch('MOMENTO_API_KEY')
-
 # Cached items will be deleted after 12.5 seconds.
 TTL_SECONDS = 12.5
 
 # The name of the cache to create *and delete*
 CACHE_NAME = ENV.fetch('MOMENTO_CACHE_NAME')
 
+# Create a credential provider that loads a Momento API Key from an environment variable.
+credential_provider = Momento::CredentialProvider.from_env_var('MOMENTO_API_KEY')
+
 # Instantiate a Momento client.
 client = Momento::SimpleCacheClient.new(
-  auth_token: TOKEN,
+  credential_provider: credential_provider,
   default_ttl: TTL_SECONDS
 )
 

--- a/examples/example.rb
+++ b/examples/example.rb
@@ -3,18 +3,18 @@
 
 require 'momento'
 
-# Get your Momento token from an environment variable.
-TOKEN = ENV.fetch('MOMENTO_API_KEY')
-
 # Cached items will be deleted after 12.5 seconds.
 TTL_SECONDS = 12.5
 
 # The name of the cache to create *and delete*
 CACHE_NAME = ENV.fetch('MOMENTO_CACHE_NAME')
 
+# Create a credential provider that loads a Momento API Key from an environment variable.
+credential_provider = Momento::CredentialProvider.from_env_var('MOMENTO_API_KEY')
+
 # Instantiate a Momento client.
 client = Momento::SimpleCacheClient.new(
-  auth_token: TOKEN,
+  credential_provider: credential_provider,
   default_ttl: TTL_SECONDS
 )
 

--- a/examples/file.rb
+++ b/examples/file.rb
@@ -5,9 +5,6 @@
 
 require 'momento'
 
-# Get your Momento token from an environment variable.
-TOKEN = ENV.fetch('MOMENTO_API_KEY')
-
 # Cached items will be deleted after 12.5 seconds.
 TTL_SECONDS = 12.5
 
@@ -21,9 +18,12 @@ FILE_LOCATIONS = [
   "../spec/support/assets/test.jpg"
 ].freeze
 
+# Create a credential provider that loads a Momento API Key from an environment variable.
+credential_provider = Momento::CredentialProvider.from_env_var('MOMENTO_API_KEY')
+
 # Instantiate a Momento client.
 client = Momento::SimpleCacheClient.new(
-  auth_token: TOKEN,
+  credential_provider: credential_provider,
   default_ttl: TTL_SECONDS
 )
 

--- a/lib/momento.rb
+++ b/lib/momento.rb
@@ -1,5 +1,6 @@
 require_relative 'momento/version'
 require_relative 'momento/simple_cache_client'
+require_relative 'momento/auth/credential_provider'
 
 # Top level namespace for all Momento code.
 module Momento

--- a/lib/momento/auth/credential_provider.rb
+++ b/lib/momento/auth/credential_provider.rb
@@ -1,0 +1,69 @@
+module Momento
+  # Contains the information required for a Momento client to connect to and authenticate with Momento services.
+  class CredentialProvider
+    attr_reader :api_key, :control_endpoint, :cache_endpoint
+
+    # Creates a CredentialProvider from a Momento API key loaded from an environment variable.
+    def self.from_env_var(env_var_name)
+      api_key = ENV.fetch(env_var_name) {
+        raise Momento::Error::InvalidArgumentError, "Env var #{env_var_name} must be set"
+      }
+      new(api_key)
+    end
+
+    # Creates a CredentialProvider from a Momento API key
+    def self.from_string(api_key)
+      raise Momento::Error::InvalidArgumentError, 'Auth token string cannot be empty' if api_key.empty?
+
+      new(api_key)
+    end
+
+    private
+
+    def initialize(api_key)
+      decoded_token = decode_api_key(api_key)
+      @api_key = decoded_token.api_key
+      @control_endpoint = decoded_token.control_endpoint
+      @cache_endpoint = decoded_token.cache_endpoint
+    rescue StandardError => e
+      raise Momento::Error::InvalidArgumentError, e.message
+    end
+
+    AuthTokenData = Struct.new(:api_key, :cache_endpoint, :control_endpoint)
+
+    def decode_api_key(api_key)
+      decode_legacy_key(api_key)
+    rescue StandardError
+      decode_v1_key(api_key)
+    end
+
+    def decode_legacy_key(api_key)
+      key_parts = api_key.split('.')
+      raise Momento::Error::InvalidArgumentError, 'Malformed legacy API key' if key_parts.size != 3
+
+      decoded_key = Base64.decode64(key_parts[1])
+      key_json = JSON.parse(decoded_key, symbolize_names: true)
+      validate_key_json(key_json, %i[c cp])
+
+      AuthTokenData.new(api_key, key_json[:c], key_json[:cp])
+    end
+
+    def decode_v1_key(api_key)
+      decoded_key = Base64.decode64(api_key)
+      key_json = JSON.parse(decoded_key, symbolize_names: true)
+      validate_key_json(key_json, %i[api_key endpoint])
+
+      AuthTokenData.new(key_json[:api_key], "cache.#{key_json[:endpoint]}", "control.#{key_json[:endpoint]}")
+    rescue StandardError
+      raise Momento::Error::InvalidArgumentError, 'Malformed Momento API Key'
+    end
+
+    def validate_key_json(key_json, required_fields)
+      missing_fields = required_fields.reject { |field| key_json.key?(field) }
+      return if missing_fields.empty?
+
+      raise Momento::Error::InvalidArgumentError,
+        "Required fields are missing: #{missing_fields.join(', ')}"
+    end
+  end
+end

--- a/lib/momento/simple_cache_client.rb
+++ b/lib/momento/simple_cache_client.rb
@@ -1,5 +1,3 @@
-require 'jwt'
-require 'base64'
 require_relative 'generated/cacheclient_services_pb'
 require_relative 'generated/controlclient_services_pb'
 require_relative 'response'
@@ -15,9 +13,9 @@ module Momento
   # Instead it returns an error response. Please see {file:README.md#label-Error+Handling}.
   #
   # @example
-  #   token = ...your Momento JWT...
+  #   credential_provider = Momento::Auth::CredentialProvider.from_env_var('MOMENTO_API_KEY')
   #   client = Momento::SimpleCacheClient.new(
-  #     auth_token: token,
+  #     credential_provider: credential_provider,
   #     # cached items will be deleted after 100 seconds
   #     default_ttl: 100
   #   )
@@ -56,12 +54,15 @@ module Momento
     # @return [Numeric] how long items should remain in the cache, in seconds.
     attr_accessor :default_ttl
 
-    # @param auth_token [String] the JWT for your Momento account
+    # @param credential_provider [Momento::Auth::CredentialProvider] the provider for the
+    # credentials required to connect to Momento
     # @param default_ttl [Numeric] time-to-live, in seconds
-    # @raise [ArgumentError] if the default_ttl or auth_token is invalid
-    def initialize(auth_token:, default_ttl:)
+    # @raise [ArgumentError] if the default_ttl or credential_provider is invalid
+    def initialize(credential_provider:, default_ttl:)
       @default_ttl = Momento::Ttl.to_ttl(default_ttl)
-      load_endpoints_from_token(auth_token)
+      @api_key = credential_provider.api_key
+      @control_endpoint = credential_provider.control_endpoint
+      @cache_endpoint = credential_provider.cache_endpoint
     end
 
     # Get a value in a cache.
@@ -277,39 +278,10 @@ module Momento
       @combined_credentials ||= make_combined_credentials
     end
 
-    def load_endpoints_from_token(auth_token)
-      if is_base64?(auth_token)
-        decoded_token = decode_base64_token(auth_token)
-        @control_endpoint = "control.#{decoded_token['endpoint']}"
-        @cache_endpoint = "cache.#{decoded_token['endpoint']}"
-        @auth_token = decoded_token['api_key']
-      else
-        claim = JWT.decode(auth_token, nil, false).first
-        @control_endpoint = claim["cp"]
-        @cache_endpoint = claim["c"]
-        @auth_token = auth_token
-      end
-    rescue JWT::DecodeError
-      raise ArgumentError, "Invalid Momento auth token."
-    end
-
-    def decode_base64_token(token)
-      base64_decoded_json = Base64.decode64(token)
-      JSON.parse(base64_decoded_json)
-    rescue JSON::ParserError
-      raise ArgumentError, "Invalid base64 encoded token."
-    end
-
-    def is_base64?(str)
-      Base64.strict_encode64(Base64.decode64(str)) == str
-    rescue ArgumentError
-      false
-    end
-
     def make_combined_credentials
       # :nocov:
       auth_proc = proc do
-        { authorization: @auth_token, agent: "ruby:#{VERSION}" }
+        { authorization: @api_key, agent: "ruby:#{VERSION}" }
       end
       # :nocov:
 

--- a/lib/momento/simple_cache_client.rb
+++ b/lib/momento/simple_cache_client.rb
@@ -13,7 +13,7 @@ module Momento
   # Instead it returns an error response. Please see {file:README.md#label-Error+Handling}.
   #
   # @example
-  #   credential_provider = Momento::Auth::CredentialProvider.from_env_var('MOMENTO_API_KEY')
+  #   credential_provider = Momento::CredentialProvider.from_env_var('MOMENTO_API_KEY')
   #   client = Momento::SimpleCacheClient.new(
   #     credential_provider: credential_provider,
   #     # cached items will be deleted after 100 seconds
@@ -54,7 +54,7 @@ module Momento
     # @return [Numeric] how long items should remain in the cache, in seconds.
     attr_accessor :default_ttl
 
-    # @param credential_provider [Momento::Auth::CredentialProvider] the provider for the
+    # @param credential_provider [Momento::CredentialProvider] the provider for the
     # credentials required to connect to Momento
     # @param default_ttl [Numeric] time-to-live, in seconds
     # @raise [ArgumentError] if the default_ttl or credential_provider is invalid

--- a/momento.gemspec
+++ b/momento.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', "~> 2.3"
   spec.add_development_dependency 'factory_bot', "~> 6.2.1"
   spec.add_development_dependency 'faker', "~> 3.0"
+  spec.add_development_dependency 'jwt', '~> 2'
   spec.add_development_dependency 'pry-byebug', '~> 3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency "rspec", "~> 3.12"
@@ -43,5 +44,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard', '~> 0.9'
 
   spec.add_dependency "grpc", '~> 1.58'
-  spec.add_dependency 'jwt', '~> 2'
 end

--- a/sig/momento/auth/credential_provider.rbs
+++ b/sig/momento/auth/credential_provider.rbs
@@ -1,0 +1,11 @@
+module Momento
+  class CredentialProvider
+    def self.from_env_var: -> CredentialProvider
+
+    def self.from_string: -> CredentialProvider
+
+    attr_reader api_key: String
+    attr_reader cache_endpoint: String
+    attr_reader control_endpoint: String
+  end
+end

--- a/spec/factories/credential_provider.rb
+++ b/spec/factories/credential_provider.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :credential_provider, class: "Momento::CredentialProvider" do
+    api_key { build(:auth_token) }
+
+    initialize_with do
+      Momento::CredentialProvider.from_string(api_key)
+    end
+  end
+end

--- a/spec/factories/simple_cache_client.rb
+++ b/spec/factories/simple_cache_client.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :momento_simple_cache_client, class: "Momento::SimpleCacheClient" do
-    auth_token { build(:auth_token) }
+    credential_provider { build(:credential_provider) }
     default_ttl { 10_000 }
 
     initialize_with do

--- a/spec/live_spec.rb
+++ b/spec/live_spec.rb
@@ -1,6 +1,6 @@
 # Live tests against the real server.
 #
-# Only runs whem MOMENTO_TEST_LIVE set.
+# Only runs when MOMENTO_TEST_LIVE set.
 #
 # Needs TEST_AUTH_TOKEN and TEST_CACHE_NAME.
 
@@ -14,7 +14,7 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
     ENV.fetch('TEST_AUTH_TOKEN')
   }
   let(:credential_provider) {
-    Momento::Auth::CredentialProvider.from_string(auth_token)
+    Momento::CredentialProvider.from_string(auth_token)
   }
   let(:cache_name) {
     ENV.fetch('TEST_CACHE_NAME')

--- a/spec/live_spec.rb
+++ b/spec/live_spec.rb
@@ -13,12 +13,15 @@ RSpec.describe 'live acceptance tests', if: ENV.fetch('MOMENTO_TEST_LIVE', nil) 
   let(:auth_token) {
     ENV.fetch('TEST_AUTH_TOKEN')
   }
+  let(:credential_provider) {
+    Momento::Auth::CredentialProvider.from_string(auth_token)
+  }
   let(:cache_name) {
     ENV.fetch('TEST_CACHE_NAME')
   }
   let(:client) {
     Momento::SimpleCacheClient.new(
-      auth_token: auth_token,
+      credential_provider: credential_provider,
       default_ttl: 10
     )
   }

--- a/spec/momento/credential_provider_spec.rb
+++ b/spec/momento/credential_provider_spec.rb
@@ -1,0 +1,89 @@
+require "momento/auth/credential_provider"
+
+CONTROL_ENDPOINT_LEGACY = "control.example.com".freeze
+CACHE_ENDPOINT_LEGACY = "cache.example.com".freeze
+CONTROL_ENDPOINT_V1 = "control.test.momentohq.com".freeze
+CACHE_ENDPOINT_V1 = "cache.test.momentohq.com".freeze
+
+# *** These API keys are fake and nonfunctional ***
+
+LEGACY_API_KEY_VALID = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbC5leGFtcGxlLmNvbSIsImMiOiJjYWNoZS\
+5leGFtcGxlLmNvbSJ9.YY7RSMBCpMRs_qgbNkW0PYC2eX-MukLixLWJyvBpnMVaOba-OV0G5jgNmNbtn4zaLT8tlEncV6wQ_CkTI_PvoA".freeze
+V1_API_KEY_VALID = "eyJhcGlfa2V5IjogImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSklVekkxTmlKOS5leUpwYzNNaU9pSlBibXhwYm1VZ1NsZFV\
+JRUoxYVd4a1pYSWlMQ0pwWVhRaU9qRTJOemd6TURVNE1USXNJbVY0Y0NJNk5EZzJOVFV4TlRReE1pd2lZWFZrSWpvaUlpd2ljM1ZpSWpvaWFuSnZZMnRsZE\
+VCbGVHRnRjR3hsTG1OdmJTSjkuOEl5OHE4NExzci1EM1lDb19IUDRkLXhqSGRUOFVDSXV2QVljeGhGTXl6OCIsICJlbmRwb2ludCI6ICJ0ZXN0Lm1vbWVud\
+G9ocS5jb20ifQ==".freeze
+V1_INNER_KEY = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2NzgzMDU4MTIsImV4cC\
+I6NDg2NTUxNTQxMiwiYXVkIjoiIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9.8Iy8q84Lsr-D3YCo_HP4d-xjHdT8UCIuvAYcxhFMyz8".freeze
+
+LEGACY_API_KEY_MISSING_CONTROL_ENDPOINT = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImMiOiJjYWNoZS5leGFtcGxlLmNvbSJ\
+9.RzLpBXut4s0fEXHtVIYVNb6Z8tiHSP9iu2j6OJpJHDksNXuOgTVFlMyG4V3gvMLMUwQmgtov-U9pMbaghQnr-Q".freeze
+LEGACY_API_KEY_MISSING_CACHE_ENDPOINT = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbC5leGFtcGxlLmNvb\
+SJ9.obg5-runV-bdp0ZTV_2DGDFdRfc6aIRHaSBGbK3QaACPXwF6e8ghBYg2LDXXOWgbdpy6wEfDVIPgYZ0yXxVqvg".freeze
+V1_API_KEY_MISSING_KEY = "eyJlbmRwb2ludCI6ICJhLmIuY29tIn0=".freeze
+V1_API_KEY_MISSING_ENDPOINT = "eyJhcGlfa2V5IjogImV5SmxibVJ3YjJsdWRDSTZJbU5sYkd3dE5DMTFjeTEzWlhOMExUSXRNUzV3Y205a0xtRXVi\
+Vzl0Wlc1MGIyaHhMbU52YlNJc0ltRndhVjlyWlhraU9pSmxlVXBvWWtkamFVOXBTa2xWZWtreFRtbEtPUzVsZVVwNlpGZEphVTlwU25kYVdGSnNURzFrYUd\
+SWVVuQmFXRXBCV2pJeGFHRlhkM1ZaTWpsMFNXbDNhV1J0Vm5sSmFtOTRabEV1VW5OMk9GazVkRE5KVEMwd1RHRjZiQzE0ZDNaSVZESmZZalJRZEhGTlVVMD\
+VRV3hhVlVsVGFrbENieUo5In0=".freeze
+
+RSpec.describe Momento::CredentialProvider do
+  describe ".from_string" do
+    context "when given a valid legacy API key" do
+      it 'creates a CredentialProvider containing valid information' do
+        credential_provider = described_class.from_string(LEGACY_API_KEY_VALID)
+        expect(credential_provider.api_key).to eq(LEGACY_API_KEY_VALID)
+        expect(credential_provider.control_endpoint).to eq(CONTROL_ENDPOINT_LEGACY)
+        expect(credential_provider.cache_endpoint).to eq(CACHE_ENDPOINT_LEGACY)
+      end
+    end
+
+    context "when given a valid V1 API key" do
+      it 'creates a CredentialProvider containing valid information' do
+        credential_provider = described_class.from_string(V1_API_KEY_VALID)
+        expect(credential_provider.api_key).to eq(V1_INNER_KEY)
+        expect(credential_provider.control_endpoint).to eq(CONTROL_ENDPOINT_V1)
+        expect(credential_provider.cache_endpoint).to eq(CACHE_ENDPOINT_V1)
+      end
+    end
+
+    context "when given an unparseable API key" do
+      it "raises an InvalidArgumentError" do
+        expect {
+          described_class.from_string("this is not a key")
+        }.to raise_error(Momento::Error::InvalidArgumentError)
+      end
+    end
+
+    context "when given a legacy API key missing a control endpoint" do
+      it 'raises an InvalidArgumentError' do
+        expect {
+          described_class.from_string(LEGACY_API_KEY_MISSING_CONTROL_ENDPOINT)
+        }.to raise_error(Momento::Error::InvalidArgumentError)
+      end
+    end
+
+    context "when given a legacy API key missing a cache endpoint" do
+      it 'raises an InvalidArgumentError' do
+        expect {
+          described_class.from_string(LEGACY_API_KEY_MISSING_CACHE_ENDPOINT)
+        }.to raise_error(Momento::Error::InvalidArgumentError)
+      end
+    end
+
+    context "when given a v1 API key missing a key" do
+      it 'raises an InvalidArgumentError' do
+        expect {
+          described_class.from_string(V1_API_KEY_MISSING_KEY)
+        }.to raise_error(Momento::Error::InvalidArgumentError)
+      end
+    end
+
+    context "when given a v1 API key missing an endpoint" do
+      it 'raises an InvalidArgumentError' do
+        expect {
+          described_class.from_string(V1_API_KEY_MISSING_ENDPOINT)
+        }.to raise_error(Momento::Error::InvalidArgumentError)
+      end
+    end
+  end
+end

--- a/spec/momento/simple_cache_client_spec.rb
+++ b/spec/momento/simple_cache_client_spec.rb
@@ -19,28 +19,14 @@ RSpec.describe Momento::SimpleCacheClient do
         expect { subject }.to raise_error(ArgumentError, /is not Numeric/)
       }
     end
-
-    context 'with an invalid JWT' do
-      let(:invalid_token) { "let me iiiin!" }
-
-      let(:client) {
-        build(:momento_simple_cache_client, auth_token: invalid_token)
-      }
-
-      it 'raises a ArgumentError' do
-        expect {
-          subject
-        }.to raise_error(
-          an_instance_of(ArgumentError).and(have_attributes(cause: JWT::DecodeError))
-        )
-      end
-    end
   end
 
   shared_examples 'a gRPC stub' do
     subject(:stub) { client.send(stub_method) }
 
-    let(:client) { build(:momento_simple_cache_client, auth_token: token) }
+    let(:client) {
+      build(:momento_simple_cache_client, credential_provider: build(:credential_provider, api_key: token))
+    }
     let(:endpoint) { Faker::Internet.domain_name }
 
     it { is_expected.to be_a stub_class }


### PR DESCRIPTION
Create a CredentialProvider class that parses legacy/v1 tokens from the command line or a string.

Make SimpleCacheClient take a CredentialProvider.

Update the examples with the new constructor.

Fix some RuboCop issues.