### PR TITLE
fix: change the ruby versions in the test action to strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.7
-          - 3.0
-          - 3.1
+          - '2.7'
+          - '3.0'
+          - '3.1'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Change the versions in the github test action to strings. They were being treated as numbers and so the 3.0 was changing to a 3, making the tests use the latest version of Ruby.