### PR TITLE
chore: split github actions workflows into on-pull-request and on-push-to-main

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,14 +1,8 @@
-name: On push or PR to main
+name: Pull Request
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
-
-permissions:
-  contents: read
-  pull-requests: write
+    branches: [ "main" ]
 
 jobs:
   momento-shared-build:
@@ -33,22 +27,6 @@ jobs:
           rubocop_extensions: rubocop-performance:gemfile rubocop-rake:gemfile rubocop-rspec:gemfile
           reporter: github-pr-review
 
-  readme:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
-
-      - name: Generate README
-        uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
-        with:
-          project_status: official
-          project_stability: alpha
-          project_type: sdk
-          sdk_language: Ruby
-          usage_example_path: ./examples/example.rb
-
   test:
     # Don't test until all code is generated.
     needs: [readme]
@@ -57,3 +35,19 @@ jobs:
       auth-token: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
     with:
       live: true
+
+  readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Verify README generation
+        uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v2
+        with:
+          project_status: official
+          project_stability: beta
+          project_type: sdk
+          sdk_language: Ruby
+          template_file: ./README.template.md
+          output_file: ./README.md
+          dev_docs_slug: ruby

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -1,0 +1,37 @@
+name: Push to Main
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs: 
+  readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+
+      - name: Generate README
+        uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v2
+        with:
+          project_status: official
+          project_stability: beta
+          project_type: sdk
+          sdk_language: Ruby
+          template_file: ./README.template.md
+          output_file: ./README.md
+          dev_docs_slug: ruby
+
+  test:
+    # Don't test until all code is generated.
+    needs: [readme]
+    uses: ./.github/workflows/test.yml
+    secrets:
+      auth-token: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+    with:
+      live: true

--- a/README.template.md
+++ b/README.template.md
@@ -1,19 +1,17 @@
 {{ ossHeader }}
 
-## Getting Started :running:
+# Momento Ruby SDK
 
-### Requirements
+To get started with Momento you will need a Momento API key. You can get one from the [Momento Console](https://console.gomomento.com/api-keys).
 
-- A Momento API key is required, you can generate one using the [Momento Console](https://console.gomomento.com)
-- Ruby 2.7 or newer.
+* Website: [https://www.gomomento.com/](https://www.gomomento.com/)
+* Momento Documentation: [https://docs.momentohq.com/](https://docs.momentohq.com/)
+* Getting Started: [https://docs.momentohq.com/getting-started](https://docs.momentohq.com/getting-started)
+* Discuss: [Momento Discord](https://discord.gg/3HkAKjUZGq)
 
-An IDE with good Ruby support, such as [RubyMine](https://www.jetbrains.com/ruby/), is recommended.
+## Packages
 
-### Examples
-
-You can find this example code and more in [the examples directory](https://github.com/momentohq/client-sdk-ruby/tree/main/examples) of this repository.
-
-### Installation
+The Momento Ruby SDK is available on [RubyGems](https://rubygems.org/gems/momento) 
 
 Install the gem and add to an application's Gemfile by executing:
 
@@ -27,19 +25,33 @@ If bundler is not being used to manage dependencies, install the gem by executin
 gem install momento
 ```
 
+You will need Ruby 2.7 or newer.
+
+An IDE with good Ruby support, such as [RubyMine](https://www.jetbrains.com/ruby/), is recommended.
+
 #### Note: M1 or M2 Macs
 
 If you're using an M1 or M2 Mac, you may have trouble installing the `grpc` gem; [see this issue for more information](https://github.com/grpc/grpc/issues/31215).
 
 [A work around](https://github.com/grpc/grpc/pull/31151#issuecomment-1310321807) is to run `bundle config build.grpc --with-ldflags="-Wl,-undefined,dynamic_lookup"` before doing `bundle install`.
 
-### Usage
+## Usage
+
+You can find this example code and more in [the examples directory](./examples) of this repository.
 
 ```ruby
-{{ usageExampleCode }}
+{% include "./examples/example.rb" %}
 ```
 
-### Error Handling
+## Getting Started and Documentation
+
+General documentation on Momento and the Momento SDKs is available on the [Momento Docs website](https://docs.momentohq.com/). Specific usage examples for the Ruby SDK are coming soon!
+
+## Examples
+
+Check out full working code in the [example](./example/) directory of this repository!
+
+## Error Handling
 
 [Momento::SimpleCacheClient](https://github.com/momentohq/client-sdk-ruby/blob/main/lib/momento/simple_cache_client.rb) follows the philosophy that when working with a service,
 [exceptions are bugs](https://www.gomomento.com/blog/exceptions-are-bugs). Minor outages are a fact of life; they are normal rather than exceptional.
@@ -72,16 +84,12 @@ Momento::SimpleCacheClient *will* raise exceptions for programmer mistakes such 
 
 See [Momento::Response](https://github.com/momentohq/client-sdk-ruby/blob/main/lib/momento/response.rb) for more about working with with error responses, and [Momento::Error](https://github.com/momentohq/client-sdk-ruby/blob/main/lib/momento/error.rb) for more about using errors.
 
-### Tuning
-
-Coming soon.
-
 ## Issues
 
 Please report any bugs, issues, requests, and feedback via this repo's [issue tracker](https://github.com/momentohq/client-sdk-ruby/issues).
 
-## Contributing
+## Developing
 
-See our [instructions for CONTRIBUTING](https://github.com/momentohq/client-sdk-ruby/blob/main/CONTRIBUTING.md).
+If you are interested in contributing to the SDK, please see the [CONTRIBUTING](./CONTRIBUTING.md) docs.
 
 {{ ossFooter }}

--- a/README.template.md
+++ b/README.template.md
@@ -29,9 +29,7 @@ You will need Ruby 2.7 or newer.
 
 An IDE with good Ruby support, such as [RubyMine](https://www.jetbrains.com/ruby/), is recommended.
 
-**Note: M1 or M2 Macs**
-
-If you're using an M1 or M2 Mac, you may have trouble installing the `grpc` gem; [see this issue for more information](https://github.com/grpc/grpc/issues/31215).
+**Note: M1 or M2 Macs**: If you're using an M1 or M2 Mac, you may have trouble installing the `grpc` gem; [see this issue for more information](https://github.com/grpc/grpc/issues/31215).
 
 [A work around](https://github.com/grpc/grpc/pull/31151#issuecomment-1310321807) is to run `bundle config build.grpc --with-ldflags="-Wl,-undefined,dynamic_lookup"` before doing `bundle install`.
 

--- a/README.template.md
+++ b/README.template.md
@@ -29,7 +29,7 @@ You will need Ruby 2.7 or newer.
 
 An IDE with good Ruby support, such as [RubyMine](https://www.jetbrains.com/ruby/), is recommended.
 
-#### Note: M1 or M2 Macs
+**Note: M1 or M2 Macs**
 
 If you're using an M1 or M2 Mac, you may have trouble installing the `grpc` gem; [see this issue for more information](https://github.com/grpc/grpc/issues/31215).
 


### PR DESCRIPTION
Addresses #132 

Don't want main branch to keep failing one check that's intended for only on-pull-request workflows