### PR TITLE
chore: add ConnectionError

### DIFF
--- a/lib/momento/error/types.rb
+++ b/lib/momento/error/types.rb
@@ -77,6 +77,21 @@ module Momento
       end
     end
 
+    # Error connecting to Momento servers.
+    class ConnectionError < RuntimeError
+      include Momento::Error
+
+      # (see Momento::Error#error_code)
+      def error_code
+        :CONNECTION_ERROR
+      end
+
+      # (see Momento::Error#message)
+      def message
+        "Error connecting to Momento servers."
+      end
+    end
+
     # System is not in a state required for the operation\'s execution
     class FailedPreconditionError < RuntimeError
       include Momento::Error

--- a/spec/momento/error/types_spec.rb
+++ b/spec/momento/error/types_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe 'Momento::Error subclasses' do
     end
   end
 
+  describe Momento::Error::ConnectionError do
+    it_behaves_like Momento::Error do
+      let(:error_code) { :CONNECTION_ERROR }
+      let(:message_re) { /Error connecting to Momento servers/ }
+    end
+  end
+
   describe Momento::Error::FailedPreconditionError do
     it_behaves_like Momento::Error do
       let(:error_code) { :FAILED_PRECONDITION_ERROR }


### PR DESCRIPTION
This commit adds the `ConnectionError`. It is currently unused but is likely to be needed in the future.