### PR TITLE
chore: always encode strings as UTF-8

### DIFF
--- a/lib/momento/get_response.rb
+++ b/lib/momento/get_response.rb
@@ -22,15 +22,12 @@ module Momento
       nil
     end
 
-    # The gotten value, if any, as a string using your default encoding or specified one.
+    # The gotten value, if any, as a UTF-8 string.
     #
-    # @param encoding [Encoding] defaults to Encoding.default_external
-    # @return [String,nil] the value, if any, re-encoded
-    # rubocop:disable Lint/UnusedMethodArgument
-    def value_string(encoding = Encoding.default_external)
+    # @return [String,nil] the value, if any.
+    def value_string
       nil
     end
-    # rubocop:enable Lint/UnusedMethodArgument
 
     # @!method to_s
     #   Displays the response and the value, if any.
@@ -53,8 +50,8 @@ module Momento
         @grpc_response.cache_body
       end
 
-      def value_string(encoding = Encoding.default_external)
-        value_bytes.dup.force_encoding(encoding)
+      def value_string
+        value_bytes.dup.force_encoding('UTF-8')
       end
 
       def to_s

--- a/spec/momento/get_response/hit_spec.rb
+++ b/spec/momento/get_response/hit_spec.rb
@@ -38,12 +38,6 @@ RSpec.describe Momento::GetResponse::Hit do
         encoding: Encoding::UTF_8
       )
     }
-
-    it 'will accept a different encoding' do
-      expect(
-        response.value_string(Encoding::Big5)
-      ).to have_attributes(encoding: Encoding::Big5)
-    end
   end
 
   describe '#to_s' do
@@ -53,7 +47,7 @@ RSpec.describe Momento::GetResponse::Hit do
       build(:momento_get_response_hit, value: value)
     }
 
-    context 'when the vaule is short' do
+    context 'when the value is short' do
       let(:value) { "short" }
 
       it { is_expected.to match(/short/) }


### PR DESCRIPTION
Ensure that strings being sent to Momento are UTF-8 encoded, unless they represent binary data. This prevents getting an error when the Ruby client with a non-UTF-8 default tries to read a UTF-8 string from the server.