### PR TITLE
chore: Remove the caches method

### DIFF
--- a/examples/compact.rb
+++ b/examples/compact.rb
@@ -24,7 +24,9 @@ response = client.create_cache(CACHE_NAME)
 raise response.error if response.error?
 
 # List our caches.
-puts "Caches: #{client.caches.to_a.join(", ")}"
+response = client.list_caches
+raise response.error if response.error?
+puts "Caches: #{response.cache_names&.join(", ")}"
 
 # Put an item in the cache.
 response = client.set(CACHE_NAME, "key", "You cached something!")

--- a/examples/example.rb
+++ b/examples/example.rb
@@ -30,7 +30,9 @@ elsif response.error?
 end
 
 # List our caches.
-puts "Caches: #{client.caches.to_a.join(", ")}"
+response = client.list_caches
+raise response.error if response.error?
+puts "Caches: #{response.cache_names&.join(", ")}"
 
 # Put an item in the cache.
 response = client.set(CACHE_NAME, "key", "You cached something!")

--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -217,13 +217,9 @@ module Momento
       end
     end
 
-    # List a page of your caches.
+    # Lists your caches.
     #
-    # This is a low-level method. You probably want to use {#caches} instead.
-    #
-    # @see #caches
     # @see Momento::ListCachesResponse
-    # @note Consider using `caches` instead.
     # @return [Momento::ListCachesResponse]
     def list_caches
       builder = ListCachesResponseBuilder.new(
@@ -234,22 +230,6 @@ module Momento
           MomentoProtos::ControlClient::PB__ListCachesRequest.new
         )
       end
-    end
-
-    # Lists the names of all your caches.
-    # @example
-    #   cache_names = client.caches
-    #   cache_names.each { |name| puts name }
-    #
-    # @note Unlike other methods, this will raise if there is a problem
-    #   with the client or service.
-    # @return [Array<String>] the cache names
-    # @raise [Momento::Error] when there is an error listing caches.
-    def caches
-      response = list_caches
-      raise response.error if response.is_a? Momento::Response::Error
-
-      response.cache_names || []
     end
 
     private

--- a/lib/momento/list_caches_response.rb
+++ b/lib/momento/list_caches_response.rb
@@ -2,17 +2,14 @@ require_relative 'response/error'
 
 module Momento
   # A response from listing the caches.
-  #
-  # Each response is a single page of caches, there may be additional pages.
-  # Use Momento::CacheClient#caches to efficiently get the whole list.
   class ListCachesResponse < Response
-    # Did it get a page of caches?
+    # Did it get a list of caches?
     # @return [Boolean]
     def success?
       false
     end
 
-    # The names of the caches in this page.
+    # The names of the caches.
     # @return [Array,nil]
     def cache_names
       nil
@@ -48,13 +45,8 @@ module Momento
       private
 
       def display_cache_names
-        display = cache_names.first(CACHE_NAMES_TO_DISPLAY).join(", ")
-
-        if cache_names.size > CACHE_NAMES_TO_DISPLAY
-          "#{display}, ..."
-        else
-          display
-        end
+        display = cache_names&.take(CACHE_NAMES_TO_DISPLAY)&.join(", ")
+        cache_names&.size&.>(CACHE_NAMES_TO_DISPLAY) ? "#{display}, ..." : display.to_s
       end
     end
 

--- a/sig/momento/list_caches_response.rbs
+++ b/sig/momento/list_caches_response.rbs
@@ -1,0 +1,7 @@
+module Momento
+  class ListCachesResponse
+    def success?: -> bool
+
+    def cache_names: -> (Array[String] | nil)
+  end
+end

--- a/spec/momento/cache_client_spec.rb
+++ b/spec/momento/cache_client_spec.rb
@@ -340,52 +340,6 @@ RSpec.describe Momento::CacheClient do
     end
   end
 
-  describe '#caches' do
-    let(:grpc_responses) {
-      [
-        build(:momento_control_client_list_caches_response)
-      ]
-    }
-
-    let(:responses) {
-      grpc_responses.map { |gr|
-        build(:momento_list_caches_response_success, grpc_response: gr)
-      }
-    }
-
-    before do
-      allow(client).to receive(:list_caches).and_return(responses[0])
-    end
-
-    it 'iterates through the responses' do
-      cache_names = responses.flat_map(&:cache_names)
-
-      expect(client.caches.to_a).to eq cache_names
-    end
-
-    it 'when list_caches has an error response, it raises the error' do
-      error_response = build(:momento_list_caches_response_error)
-
-      allow(client).to receive(:list_caches)
-        .and_return(error_response)
-
-      expect {
-        client.caches.to_a
-      }.to raise_error(error_response.error)
-    end
-
-    it 'when list_caches raises, it raises' do
-      error = "the front fell off"
-
-      allow(client).to receive(:list_caches)
-        .and_raise(error)
-
-      expect {
-        client.caches.to_a
-      }.to raise_error(error)
-    end
-  end
-
   describe '#get' do
     subject { client.get(cache_name, key) }
 


### PR DESCRIPTION
Remove the caches method. Since pagination doesn't exist yet, it doesn't do anything other than providing a slightly different version of the list_caches method.