### PR TITLE
feat: add sorted set put and fetch by score

### DIFF
--- a/examples/compact.rb
+++ b/examples/compact.rb
@@ -2,8 +2,8 @@
 
 require 'momento'
 
-# Cached items will be deleted after 12.5 seconds.
-TTL_SECONDS = 12.5
+# Cached items will be deleted after 10 seconds.
+TTL_SECONDS = 10
 
 # The name of the cache to create *and delete*
 CACHE_NAME = ENV.fetch('MOMENTO_CACHE_NAME')
@@ -26,6 +26,7 @@ raise response.error if response.error?
 # List our caches.
 response = client.list_caches
 raise response.error if response.error?
+
 puts "Caches: #{response.cache_names&.join(", ")}"
 
 # Put an item in the cache.

--- a/examples/example.rb
+++ b/examples/example.rb
@@ -31,8 +31,11 @@ end
 
 # List our caches.
 response = client.list_caches
-raise response.error if response.error?
-puts "Caches: #{response.cache_names&.join(", ")}"
+if response.success?
+  puts "Caches: #{response.cache_names&.join(", ")}"
+elsif response.error?
+  raise "Couldn't list the caches: #{response.error}"
+end
 
 # Put an item in the cache.
 response = client.set(CACHE_NAME, "key", "You cached something!")

--- a/lib/momento.rb
+++ b/lib/momento.rb
@@ -1,8 +1,10 @@
 require_relative 'momento/version'
 require_relative 'momento/cache_client'
+require_relative 'momento/collection_ttl'
 require_relative 'momento/auth/credential_provider'
 require_relative 'momento/config/configuration'
 require_relative 'momento/config/configurations'
+require_relative 'momento/response/sort_order'
 
 # Top level namespace for all Momento code.
 module Momento

--- a/lib/momento/collection_ttl.rb
+++ b/lib/momento/collection_ttl.rb
@@ -1,0 +1,60 @@
+module Momento
+  # Represents the desired behavior for managing the TTL on collection objects.
+  #
+  # For cache operations that modify a collection (dictionaries, lists, or sets), there
+  # are a few things to consider. The first time the collection is created, we need to
+  # set a TTL on it. For subsequent operations that modify the collection you may choose
+  # to update the TTL in order to prolong the life of the cached collection object, or
+  # you may choose to leave the TTL unmodified in order to ensure that the collection
+  # expires at the original TTL.
+  #
+  # The default behaviour is to refresh the TTL (to prolong the life of the collection)
+  # each time it is written using the client's default item TTL.
+  class CollectionTtl
+    attr_reader :ttl_seconds, :refresh_ttl
+
+    def initialize(ttl_seconds = nil, refresh_ttl: true)
+      validate_ttl_seconds(ttl_seconds) unless ttl_seconds.nil?
+      @ttl_seconds = ttl_seconds
+      @refresh_ttl = refresh_ttl
+    end
+
+    def ttl_milliseconds
+      @ttl_seconds.nil? ? nil : @ttl_seconds * 1000
+    end
+
+    def self.from_cache_ttl
+      new(nil, true)
+    end
+
+    def self.of(ttl_seconds)
+      new(ttl_seconds, true)
+    end
+
+    def self.refresh_ttl_if_provided(ttl_seconds = nil)
+      new(ttl_seconds, !ttl_seconds.nil?)
+    end
+
+    def with_ttl_if_absent(ttl_seconds)
+      self.class.new(@ttl_seconds || ttl_seconds, @refresh_ttl)
+    end
+
+    def with_refresh_ttl_on_updates
+      self.class.new(@ttl_seconds, true)
+    end
+
+    def with_no_refresh_ttl_on_updates
+      self.class.new(@ttl_seconds, false)
+    end
+
+    def to_s
+      "ttl: #{@ttl_seconds || 'null'}, refreshTtl: #{@refresh_ttl ? 'true' : 'false'}"
+    end
+
+    private
+
+    def validate_ttl_seconds(ttl_seconds)
+      raise ArgumentError, "TTL must be a positive integer" unless ttl_seconds.is_a?(Integer) && ttl_seconds.positive?
+    end
+  end
+end

--- a/lib/momento/collection_ttl.rb
+++ b/lib/momento/collection_ttl.rb
@@ -24,27 +24,27 @@ module Momento
     end
 
     def self.from_cache_ttl
-      new(nil, true)
+      new
     end
 
     def self.of(ttl_seconds)
-      new(ttl_seconds, true)
+      new(ttl_seconds)
     end
 
     def self.refresh_ttl_if_provided(ttl_seconds = nil)
-      new(ttl_seconds, !ttl_seconds.nil?)
+      new(ttl_seconds, refresh_ttl: !ttl_seconds.nil?)
     end
 
     def with_ttl_if_absent(ttl_seconds)
-      self.class.new(@ttl_seconds || ttl_seconds, @refresh_ttl)
+      self.class.new(@ttl_seconds || ttl_seconds, refresh_ttl: @refresh_ttl)
     end
 
     def with_refresh_ttl_on_updates
-      self.class.new(@ttl_seconds, true)
+      self.class.new(@ttl_seconds)
     end
 
     def with_no_refresh_ttl_on_updates
-      self.class.new(@ttl_seconds, false)
+      self.class.new(@ttl_seconds, refresh_ttl: false)
     end
 
     def to_s

--- a/lib/momento/response.rb
+++ b/lib/momento/response.rb
@@ -17,6 +17,9 @@ require_relative 'list_caches_response'
 require_relative 'list_caches_response_builder'
 require_relative 'set_response'
 require_relative 'set_response_builder'
+require_relative 'response/sorted_set/sorted_set_put_element_response'
+require_relative 'response/sorted_set/sorted_set_put_elements_response'
+require_relative 'response/sorted_set/sorted_set_fetch_response'
 
 module Momento
   # The response from a Momento service request.

--- a/lib/momento/response/sort_order.rb
+++ b/lib/momento/response/sort_order.rb
@@ -1,0 +1,11 @@
+module Momento
+  # Represents whether a collection is sorted in ascending or descending fashion.
+  class SortOrder
+    ASCENDING = :ascending
+    DESCENDING = :descending
+
+    def self.valid?(order)
+      [ASCENDING, DESCENDING].include?(order)
+    end
+  end
+end

--- a/lib/momento/response/sorted_set/sorted_set_fetch_response.rb
+++ b/lib/momento/response/sorted_set/sorted_set_fetch_response.rb
@@ -1,0 +1,104 @@
+require 'grpc'
+require_relative '../error'
+require_relative '../../generated/cacheclient_pb'
+
+module Momento
+  # A response containing the elements retrieved from a sorted set.
+  class SortedSetFetchResponse < Response
+    # The sorted set exists and any matching elements were fetched.
+    # @return [Boolean]
+    def hit?
+      false
+    end
+
+    # The sorted set does not exist.
+    # @return [Boolean]
+    def miss?
+      false
+    end
+
+    # The fetched values as UTF-8 Strings and their scores.
+    # @return [(Array[{ value: String, score: Float }] | nil)] the UTF-8 elements and their scores
+    def value_string_elements
+      nil
+    end
+
+    # The fetched values as ASCII_8BIT Strings and their scores.
+    # @return [(Array[{ value: String, score: Float }] | nil)] the ASCII_8BIT elements and their scores
+    def value_bytes_elements
+      nil
+    end
+
+    # @!method to_s
+    #   Displays the response and the value, if any.
+    #   A long value will be truncated.
+    #   @return [String]
+
+    # @private
+    class Hit < SortedSetFetchResponse
+      # rubocop:disable Lint/MissingSuper
+      def initialize(grpc_response:)
+        @grpc_response = grpc_response
+      end
+      # rubocop:enable Lint/MissingSuper
+
+      def hit?
+        true
+      end
+
+      def value_string_elements
+        @grpc_response.elements.map do |element|
+          { value: element.value.dup.force_encoding('UTF-8'), score: element.score }
+        end
+      end
+
+      def value_bytes_elements
+        @grpc_response.elements.map do |element|
+          { value: element.value, score: element.score }
+        end
+      end
+
+      def to_s
+        "#{super}: #{display_string(value_string)}"
+      end
+    end
+
+    # @private
+    class Miss < SortedSetFetchResponse
+      def miss?
+        true
+      end
+    end
+
+    # @private
+    class Error < SortedSetFetchResponse
+      include Momento::Response::Error
+    end
+  end
+
+  # @private
+  class SortedSetFetchResponseBuilder < ResponseBuilder
+    # Build a Momento::SortedSetFetchResponse from a block of code
+    # which returns a MomentoProtos::CacheClient::PB__SortedSetFetchResponse.
+    #
+    # @return [Momento::SortedSetFetchResponse]
+    # @raise [StandardError] when the exception is not recognized.
+    # @raise [TypeError] when the response is not recognized.
+    def from_block
+      response = yield
+    rescue *RESCUED_EXCEPTIONS => e
+      SortedSetFetchResponse::Error.new(exception: e, context: context)
+    else
+      raise TypeError unless response.is_a?(MomentoProtos::CacheClient::PB__SortedSetFetchResponse)
+
+      case response.sorted_set
+      when :found
+        SortedSetFetchResponse::Hit.new(grpc_response: response.found.values_with_scores)
+      when :missing
+        SortedSetFetchResponse::Miss.new
+      else
+        raise "Unknown sorted set fetch result: #{response.sorted_set}"
+      end
+    end
+  end
+end

--- a/lib/momento/response/sorted_set/sorted_set_put_element_response.rb
+++ b/lib/momento/response/sorted_set/sorted_set_put_element_response.rb
@@ -1,0 +1,45 @@
+require 'grpc'
+require_relative '../error'
+require_relative '../../generated/cacheclient_pb'
+
+module Momento
+  # A response representing the result of a sorted set put element operation.
+  class SortedSetPutElementResponse < Response
+    # Was the element added to the sorted set?
+    # @return [Boolean]
+    def success?
+      false
+    end
+
+    # @private
+    class Success < SortedSetPutElementResponse
+      def success?
+        true
+      end
+    end
+
+    # @private
+    class Error < SortedSetPutElementResponse
+      include Momento::Response::Error
+    end
+  end
+
+  # @private
+  class SortedSetPutElementResponseBuilder < ResponseBuilder
+    # Build a Momento::SortedSetPutElementResponse from a block of code
+    # which returns a MomentoProtos::CacheClient::PB__SortedSetPutElementResponse.
+    #
+    # @return [Momento::SortedSetPutElementResponse]
+    # @raise [StandardError] when the exception is not recognized.
+    # @raise [TypeError] when the response is not recognized.
+    def from_block
+      response = yield
+    rescue *RESCUED_EXCEPTIONS => e
+      SortedSetPutElementResponse::Error.new(exception: e, context: context)
+    else
+      raise TypeError unless response.is_a?(::MomentoProtos::CacheClient::PB__SortedSetPutResponse)
+
+      SortedSetPutElementResponse::Success.new
+    end
+  end
+end

--- a/lib/momento/response/sorted_set/sorted_set_put_elements_response.rb
+++ b/lib/momento/response/sorted_set/sorted_set_put_elements_response.rb
@@ -1,0 +1,45 @@
+require 'grpc'
+require_relative '../error'
+require_relative '../../generated/cacheclient_pb'
+
+module Momento
+  # A response representing the result of a sorted set put elements operation.
+  class SortedSetPutElementsResponse < Response
+    # Were the elements added to the sorted set?
+    # @return [Boolean]
+    def success?
+      false
+    end
+
+    # @private
+    class Success < SortedSetPutElementsResponse
+      def success?
+        true
+      end
+    end
+
+    # @private
+    class Error < SortedSetPutElementsResponse
+      include Momento::Response::Error
+    end
+  end
+
+  # @private
+  class SortedSetPutElementsResponseBuilder < ResponseBuilder
+    # Build a Momento::SortedSetPutElementsResponse from a block of code
+    # which returns a MomentoProtos::CacheClient::PB__SortedSetPutElementsResponse.
+    #
+    # @return [Momento::SortedSetPutElementsResponse]
+    # @raise [StandardError] when the exception is not recognized.
+    # @raise [TypeError] when the response is not recognized.
+    def from_block
+      response = yield
+    rescue *RESCUED_EXCEPTIONS => e
+      SortedSetPutElementsResponse::Error.new(exception: e, context: context)
+    else
+      raise TypeError unless response.is_a?(::MomentoProtos::CacheClient::PB__SortedSetPutResponse)
+
+      SortedSetPutElementsResponse::Success.new
+    end
+  end
+end

--- a/sig/momento/cache_client.rbs
+++ b/sig/momento/cache_client.rbs
@@ -1,0 +1,12 @@
+module Momento
+  class CacheClient
+
+    def sorted_set_fetch_by_score: (cache_name: String, sorted_set_name: String, min_score: Float | nil, max_score: Float | nil, sort_order: Symbol, offset: Integer, count: Integer) -> SortedSetFetchResponse
+
+    def sorted_set_put_element: (cache_name: String, sorted_set_name: String, value: String, score: Float, collection_ttl: CollectionTtl) -> SortedSetPutElementResponse
+
+    type value_score_pair = [String, Float]
+    type value_score_hash = { value: String, score: Float }
+    def sorted_set_put_elements: (cache_name: String, sorted_set_name: String, elements: (Hash[String, Float] | Array[value_score_pair] | Array[value_score_hash]), collection_ttl: CollectionTtl) -> SortedSetPutElementsResponse
+  end
+end

--- a/sig/momento/collection_ttl.rbs
+++ b/sig/momento/collection_ttl.rbs
@@ -1,0 +1,20 @@
+module Momento
+  class CollectionTtl
+    def self.from_cache_ttl: -> CollectionTtl
+
+    def self.of: -> CollectionTtl
+
+    def self.refresh_ttl_if_provided: -> CollectionTtl
+
+    attr_reader refresh_ttl: bool
+    attr_reader ttl_seconds: (Integer | nil)
+
+    def ttl_milliseconds: -> (Integer | nil)
+
+    def with_no_refresh_ttl_on_updates: -> CollectionTtl
+
+    def with_refresh_ttl_on_updates: -> CollectionTtl
+
+    def with_ttl_if_absent: -> CollectionTtl
+  end
+end

--- a/sig/momento/sorted_set_fetch_response.rbs
+++ b/sig/momento/sorted_set_fetch_response.rbs
@@ -1,0 +1,11 @@
+module Momento
+  class SortedSetFetchResponse
+    def hit?: -> bool
+
+    def miss?: -> bool
+
+    def value_bytes_elements: -> (Array[{ value: String, score: Float }] | nil)
+
+    def value_string_elements: -> (Array[{ value: String, score: Float }] | nil)
+  end
+end

--- a/sig/momento/sorted_set_put_element_response.rbs
+++ b/sig/momento/sorted_set_put_element_response.rbs
@@ -1,0 +1,5 @@
+module Momento
+  class SortedSetPutElementResponse
+    def success?: -> bool
+  end
+end

--- a/sig/momento/sorted_set_put_elements_response.rbs
+++ b/sig/momento/sorted_set_put_elements_response.rbs
@@ -1,0 +1,5 @@
+module Momento
+  class SortedSetPutElementsResponse
+    def success?: -> bool
+  end
+end

--- a/spec/integration/momento/cache_client_sorted_set_spec.rb
+++ b/spec/integration/momento/cache_client_sorted_set_spec.rb
@@ -1,0 +1,181 @@
+require 'momento'
+require_relative '../spec_helper'
+
+RSpec.describe Momento::CacheClient do
+  let(:client) {
+    ClientStateManager.cache_client
+  }
+  let(:cache_name) {
+    ClientStateManager.cache_name
+  }
+  let(:sorted_set_name) {
+    generate_random_string
+  }
+  let(:value) {
+    generate_random_string
+  }
+  let(:score) {
+    1.0
+  }
+
+  describe '#sorted_set_put_element' do
+    subject {
+      client.sorted_set_put_element(cache_name, sorted_set_name, value, score)
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when writing a string' do
+      it 'succeeds' do
+        expect(subject).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_string_elements: [{ value: value, score: 1.0 }]
+              )
+      end
+
+      it 'overwrites existing values' do
+        expect(subject).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_string_elements: [{ value: value, score: 1.0 }]
+              )
+
+        expect(client.sorted_set_put_element(cache_name, sorted_set_name, value, 999.0)).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_string_elements: [{ value: value, score: 999.0 }]
+              )
+      end
+    end
+
+    context 'when writing binary data' do
+      let(:value) {
+        File.read("spec/support/assets/test.jpg", encoding: Encoding::ASCII_8BIT)
+      }
+
+      it 'succeeds' do
+        expect(subject).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_bytes_elements: [{ value: value, score: 1.0 }]
+              )
+      end
+    end
+
+    context 'when writing an element with a short ttl' do
+      it 'succeeds and the element times out before it can be read' do
+        expect(client.sorted_set_put_element(cache_name, sorted_set_name, value, score,
+          collection_ttl: Momento::CollectionTtl.of(1)
+        )
+              ).to be_success
+
+        sleep(2)
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(miss?: true)
+      end
+    end
+  end
+
+  describe '#sorted_set_put_elements' do
+    subject {
+      client.sorted_set_put_elements(cache_name, sorted_set_name, { value => score })
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when writing String' do
+      it 'succeeds' do
+        expect(client.sorted_set_put_elements(cache_name, sorted_set_name, [[value, score], ['a', 0.0]])).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_string_elements: [{ value: 'a', score: 0.0 }, { value: value, score: 1.0 }]
+              )
+      end
+    end
+
+    context 'when writing binary data' do
+      let(:value) {
+        File.read("spec/support/assets/test.jpg", encoding: Encoding::ASCII_8BIT)
+      }
+
+      it 'succeeds' do
+        expect(client.sorted_set_put_elements(cache_name, sorted_set_name, { value => score })).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_bytes_elements: [{ value: value, score: 1.0 }]
+              )
+      end
+    end
+  end
+
+  describe '#sorted_set_fetch_by_score' do
+    subject {
+      client.sorted_set_fetch_by_score(cache_name, sorted_set_name)
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when fetching a non-existent set' do
+      it 'misses' do
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name)).to have_attributes(miss?: true)
+      end
+    end
+
+    context 'when fetching string data' do
+      before {
+        client.sorted_set_put_elements(cache_name, sorted_set_name, {
+          '1' => 0.0,
+          '2' => 1.0,
+          '3' => 0.5,
+          '4' => 2.0,
+          '5' => 1.5
+        }
+        )
+      }
+
+      it 'is able to fetch a full set ascending, with an end score larger than any in the set' do
+        response = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, min_score: 0.0, max_score: 9.9)
+        expect(response).to have_attributes(hit?: true)
+
+        values = response.value_string_elements&.map { |hash| hash[:value] }
+        expect(values).to eq(%w[1 3 2 5 4])
+      end
+
+      it 'is able to fetch part of the set descending, limited by the scores' do
+        response = client.sorted_set_fetch_by_score(cache_name, sorted_set_name,
+          sort_order: Momento::SortOrder::DESCENDING, min_score: 0.1, max_score: 1.9
+        )
+        expect(response).to have_attributes(hit?: true)
+
+        values = response.value_string_elements&.map { |hash| hash[:value] }
+        expect(values).to eq(%w[5 2 3])
+      end
+
+      it 'is able to fetch part of the set, limited by offset and count' do
+        response = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, offset: 1, count: 3)
+        expect(response).to have_attributes(hit?: true)
+
+        values = response.value_string_elements&.map { |hash| hash[:value] }
+        expect(values).to eq(%w[3 2 5])
+      end
+
+      it 'returns a hit with no elements if the set exists, but the parameters do not match anything' do
+        response = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, offset: 9999)
+        expect(response).to have_attributes(hit?: true)
+
+        expect(response.value_string_elements).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add sorted set put element and put elements. Put elements can take in the sorted set in a variety of formats.

Add sorted set fetch by score. It returns its result as an array of hashes [{value: "value", score: 1.0}].

Fix some rubocop warnings