### PR TITLE
feat: support UTF-8 cache names instead of just ASCII

### DIFF
--- a/spec/integration/shared_examples.rb
+++ b/spec/integration/shared_examples.rb
@@ -5,7 +5,7 @@ module SharedExamples
   end
 
   RSpec.shared_context 'when the cache name is invalid', :include_invalid_cache_name do
-    let(:cache_name) { "süpé® çåçhê 9ººº" }
+    let(:cache_name) { "\xFF" }
   end
 
   RSpec.shared_examples 'it handles invalid caches' do

--- a/spec/momento/cache_client_spec.rb
+++ b/spec/momento/cache_client_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe Momento::CacheClient do
       }
     end
 
-    context 'with a non-ASCII cache name' do
-      let(:cache_name) { "caché" }
+    context 'with a non-UTF-8 compatible cache name' do
+      let(:cache_name) { "\xFF" }
 
       it {
         is_expected.to have_attributes(


### PR DESCRIPTION
Update the validate_cache_name function to return a UTF-8 encoded version of the cache name. If it already is UTF-8, this won't do anything. If it contains bytes that can't be encoded in UTF-8, it raises an error.

Use the result of validate_cache_name in the cache functions.