### PR TITLE
feat: add support for multiple grpc channels, fix configuration modifiers

### DIFF
--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -341,10 +341,12 @@ module Momento
     private
 
     def cache_stub
-      @cache_stubs ||= (1..@num_cache_stubs).map { CACHE_CLIENT_STUB_CLASS.new(@cache_endpoint, combined_credentials,
-        timeout: @configuration.transport_strategy.grpc_configuration.deadline,
-        channel_args: { 'grpc.use_local_subchannel_pool' => 1}
-      ) }
+      @cache_stubs ||= (1..@num_cache_stubs).map {
+        CACHE_CLIENT_STUB_CLASS.new(@cache_endpoint, combined_credentials,
+          timeout: @configuration.transport_strategy.grpc_configuration.deadline,
+          channel_args: { 'grpc.use_local_subchannel_pool' => 1 }
+        )
+      }
       @next_cache_stub_index = (@next_cache_stub_index + 1) % @num_cache_stubs
       @cache_stubs[@next_cache_stub_index]
     end

--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -346,7 +346,6 @@ module Momento
         channel_args: { 'grpc.use_local_subchannel_pool' => 1}
       ) }
       @next_cache_stub_index = (@next_cache_stub_index + 1) % @num_cache_stubs
-      puts "Next cache stub index: #{@next_cache_stub_index}"
       @cache_stubs[@next_cache_stub_index]
     end
 

--- a/lib/momento/config/configuration.rb
+++ b/lib/momento/config/configuration.rb
@@ -4,8 +4,18 @@ module Momento
     class Configuration
       attr_reader :transport_strategy
 
-      def self.with_transport_strategy(transport_strategy)
+      # Copy constructor; creates a new Configuration with the specified transport strategy
+      def with_transport_strategy(transport_strategy)
         return Configuration.new(transport_strategy)
+      end
+
+      # Convenience function to set the number of TCP connections for the client. Each connection can multiplex up
+      # to 100 concurrent requests. The default is 1, and this should not be overridden unless you are making a high
+      # volume of requests. Can help distribute traffic more evenly for high-throughput use cases.
+      def with_num_connections(num_connections)
+        transport_strategy = @transport_strategy
+        grpc_config = transport_strategy.grpc_configuration
+        return Configuration.new(transport_strategy.with_grpc_configuration(grpc_config.with_num_grpc_channels(num_connections)))
       end
 
       def initialize(transport_strategy)

--- a/lib/momento/config/configuration.rb
+++ b/lib/momento/config/configuration.rb
@@ -6,7 +6,7 @@ module Momento
 
       # Copy constructor; creates a new Configuration with the specified transport strategy
       def with_transport_strategy(transport_strategy)
-        return Configuration.new(transport_strategy)
+        Configuration.new(transport_strategy)
       end
 
       # Convenience function to set the number of TCP connections for the client. Each connection can multiplex up
@@ -15,7 +15,11 @@ module Momento
       def with_num_connections(num_connections)
         transport_strategy = @transport_strategy
         grpc_config = transport_strategy.grpc_configuration
-        return Configuration.new(transport_strategy.with_grpc_configuration(grpc_config.with_num_grpc_channels(num_connections)))
+        Configuration.new(
+          transport_strategy.with_grpc_configuration(
+            grpc_config.with_num_grpc_channels(num_connections)
+          )
+        )
       end
 
       def initialize(transport_strategy)

--- a/lib/momento/config/transport/grpc_configuration.rb
+++ b/lib/momento/config/transport/grpc_configuration.rb
@@ -5,11 +5,20 @@ module Momento
     # complete before it is terminated with a DeadlineExceeded error
     attr_reader :deadline
 
-    def self.with_deadline(deadline)
-      return GrpcConfiguration.new(deadline)
+    # Number of gRPC channels to create. Each channel can multiplex up to
+    # 100 concurrent requests. The default is 1, and this should not be
+    # overridden unless you are making a high volume of requests.
+    attr_reader :num_grpc_channels
+
+    def with_deadline(deadline)
+      return GrpcConfiguration.new(deadline, @num_grpc_channels)
     end
 
-    def initialize(deadline)
+    def with_num_grpc_channels(num_grpc_channels)
+      return GrpcConfiguration.new(@deadline, num_grpc_channels)
+    end
+
+    def initialize(deadline, num_grpc_channels = 1)
       unless deadline.is_a? Integer
         raise Momento::Error::InvalidArgumentError,
           'Client timeout must be an integer'
@@ -20,6 +29,7 @@ module Momento
       end
 
       @deadline = deadline
+      @num_grpc_channels = num_grpc_channels
     end
   end
 end

--- a/lib/momento/config/transport/static_transport_strategy.rb
+++ b/lib/momento/config/transport/static_transport_strategy.rb
@@ -5,7 +5,7 @@ module Momento
   class StaticTransportStrategy < TransportStrategy
     attr_reader :grpc_configuration
 
-    def self.with_grpc_configuration(grpc_configuration)
+    def with_grpc_configuration(grpc_configuration)
       return StaticTransportStrategy.new(grpc_configuration)
     end
   end

--- a/lib/momento/config/transport/transport_strategy.rb
+++ b/lib/momento/config/transport/transport_strategy.rb
@@ -3,7 +3,7 @@ module Momento
   class TransportStrategy
     attr_reader :grpc_configuration
 
-    def self.with_grpc_configuration(grpc_configuration)
+    def with_grpc_configuration(grpc_configuration)
       return TransportStrategy.new(grpc_configuration)
     end
 

--- a/sig/momento/config/configuration.rbs
+++ b/sig/momento/config/configuration.rbs
@@ -1,6 +1,8 @@
 module Momento
   module Cache
     class Configuration
+      def self.with_num_connections: -> Cache::Configuration
+
       def self.with_transport_strategy: -> Cache::Configuration
 
       attr_reader transport_strategy: TransportStrategy

--- a/sig/momento/config/transport/grpc_configuration.rbs
+++ b/sig/momento/config/transport/grpc_configuration.rbs
@@ -2,6 +2,8 @@ module Momento
   class GrpcConfiguration
     def self.with_deadline: -> GrpcConfiguration
 
+    def self.with_num_grpc_channels: -> GrpcConfiguration
+
     attr_reader deadline: Integer
   end
 end

--- a/spec/momento/cache_client_spec.rb
+++ b/spec/momento/cache_client_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe Momento::CacheClient do
       stub
 
       expect(stub_class).to have_received(:new)
-        .with(endpoint, instance_of(GRPC::Core::ChannelCredentials), { timeout: 5000 })
+        .with(endpoint, instance_of(GRPC::Core::ChannelCredentials), { timeout: 5000,
+channel_args: { "grpc.use_local_subchannel_pool" => 1 } }
+        )
     end
   end
 


### PR DESCRIPTION
This commit does the following:

* Fix the configuration modifier methods in the classes in the config tree; they were using `self.` methods, which are actually static methods
* Add support for configuring the number of grpc channels.

Tested the grpc channel support by modifying the example code and using `lsof`.