### PR TITLE
feat: add runtime version header, only send agent headers on first request

### DIFF
--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -452,8 +452,8 @@ module Momento
         @is_first_request = false
         {
           cache: validate_cache_name(cache_name),
-          agent: "ruby:cache:#{VERSION}",
-          'runtime-version': "ruby:#{RUBY_VERSION}"
+          'Agent': "ruby:cache:#{VERSION}",
+          'Runtime-Version': "ruby:#{RUBY_VERSION}"
         }
       else
         { cache: validate_cache_name(cache_name) }

--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -449,19 +449,18 @@ module Momento
 
     def grpc_metadata(cache_name)
       metadata = if @is_first_request
-        @is_first_request = false
-        {
-          cache: validate_cache_name(cache_name),
-          agent: "ruby:cache:#{VERSION}",
-          "runtime-version": "ruby:#{RUBY_VERSION}",
-        }
-      else
-        { cache: validate_cache_name(cache_name) }
-      end
+                   @is_first_request = false
+                   {
+                     cache: validate_cache_name(cache_name),
+                     agent: "ruby:cache:#{VERSION}",
+                     'runtime-version': "ruby:#{RUBY_VERSION}"
+                   }
+                 else
+                   { cache: validate_cache_name(cache_name) }
+                 end
       puts "Using metadata: #{metadata}"
       metadata
     end
-
 
     # Return a UTF-8 version of the cache name.
     #

--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -448,18 +448,16 @@ module Momento
     end
 
     def grpc_metadata(cache_name)
-      metadata = if @is_first_request
-                   @is_first_request = false
-                   {
-                     cache: validate_cache_name(cache_name),
-                     agent: "ruby:cache:#{VERSION}",
-                     'runtime-version': "ruby:#{RUBY_VERSION}"
-                   }
-                 else
-                   { cache: validate_cache_name(cache_name) }
-                 end
-      puts "Using metadata: #{metadata}"
-      metadata
+      if @is_first_request
+        @is_first_request = false
+        {
+          cache: validate_cache_name(cache_name),
+          agent: "ruby:cache:#{VERSION}",
+          'runtime-version': "ruby:#{RUBY_VERSION}"
+        }
+      else
+        { cache: validate_cache_name(cache_name) }
+      end
     end
 
     # Return a UTF-8 version of the cache name.

--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -452,7 +452,7 @@ module Momento
         @is_first_request = false
         {
           cache: validate_cache_name(cache_name),
-          'Agent': "ruby:cache:#{VERSION}",
+          Agent: "ruby:cache:#{VERSION}",
           'Runtime-Version': "ruby:#{RUBY_VERSION}"
         }
       else

--- a/sig/momento/cache_client.rbs
+++ b/sig/momento/cache_client.rbs
@@ -1,6 +1,5 @@
 module Momento
   class CacheClient
-
     def sorted_set_fetch_by_score: (cache_name: String, sorted_set_name: String, min_score: Float | nil, max_score: Float | nil, sort_order: Symbol, offset: Integer, count: Integer) -> SortedSetFetchResponse
 
     def sorted_set_put_element: (cache_name: String, sorted_set_name: String, value: String, score: Float, collection_ttl: CollectionTtl) -> SortedSetPutElementResponse

--- a/spec/momento/cache_client_spec.rb
+++ b/spec/momento/cache_client_spec.rb
@@ -360,7 +360,7 @@ channel_args: { "grpc.use_local_subchannel_pool" => 1 } }
       expect(cache_stub).to have_received(:get)
         .with(
           be_a(MomentoProtos::CacheClient::PB__GetRequest).and(have_attributes(cache_key: key)),
-          metadata: { cache: cache_name }
+          metadata: hash_including(cache: cache_name)
         )
     end
 
@@ -480,7 +480,7 @@ channel_args: { "grpc.use_local_subchannel_pool" => 1 } }
         expect(cache_stub).to have_received(:set)
           .with(
             request_expectation,
-            metadata: { cache: cache_name }
+            metadata: hash_including(cache: cache_name)
           )
       end
     end
@@ -605,7 +605,7 @@ channel_args: { "grpc.use_local_subchannel_pool" => 1 } }
       expect(cache_stub).to have_received(:delete)
         .with(
           be_a(MomentoProtos::CacheClient::PB__DeleteRequest).and(have_attributes(cache_key: key)),
-          metadata: { cache: cache_name }
+          metadata: hash_including(cache: cache_name)
         )
     end
 


### PR DESCRIPTION
This commit does the following:

* Updates the code so that the agent header is only sent on the first request
* Adds the runtime-version header to report the ruby version
* adds the ":cache:" to the agent header to identify which client