### PR TITLE
fix: disable dynamic DNS service config

### DIFF
--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -345,7 +345,9 @@ module Momento
       @cache_stubs ||= (1..@num_cache_stubs).map {
         CACHE_CLIENT_STUB_CLASS.new(@cache_endpoint, combined_credentials,
           timeout: @configuration.transport_strategy.grpc_configuration.deadline,
-          channel_args: { 'grpc.use_local_subchannel_pool' => 1 }
+          channel_args: { 'grpc.use_local_subchannel_pool' => 1,
+                          'grpc.service_config_disable_resolution' => 1 # Disable service config resolution to avoid DNS TXT record lookups
+          }
         )
       }
       @next_cache_stub_index = (@next_cache_stub_index + 1) % @num_cache_stubs
@@ -353,7 +355,9 @@ module Momento
     end
 
     def control_stub
-      @control_stub ||= CONTROL_CLIENT_STUB_CLASS.new(@control_endpoint, combined_credentials)
+      @control_stub ||= CONTROL_CLIENT_STUB_CLASS.new(@control_endpoint, combined_credentials,
+          channel_args: { 'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution here
+      )
     end
 
     def combined_credentials

--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -355,7 +355,7 @@ module Momento
 
     def control_stub
       @control_stub ||= CONTROL_CLIENT_STUB_CLASS.new(@control_endpoint, combined_credentials,
-            channel_args: { 'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution here
+        channel_args: { 'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution here
       )
     end
 

--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -355,7 +355,7 @@ module Momento
 
     def control_stub
       @control_stub ||= CONTROL_CLIENT_STUB_CLASS.new(@control_endpoint, combined_credentials,
-        channel_args: { 'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution here
+        channel_args: { 'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution to avoid DNS TXT record lookups
       )
     end
 

--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -346,8 +346,7 @@ module Momento
         CACHE_CLIENT_STUB_CLASS.new(@cache_endpoint, combined_credentials,
           timeout: @configuration.transport_strategy.grpc_configuration.deadline,
           channel_args: { 'grpc.use_local_subchannel_pool' => 1,
-                          'grpc.service_config_disable_resolution' => 1 # Disable service config resolution to avoid DNS TXT record lookups
-          }
+                          'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution to avoid DNS TXT record lookups
         )
       }
       @next_cache_stub_index = (@next_cache_stub_index + 1) % @num_cache_stubs
@@ -356,7 +355,7 @@ module Momento
 
     def control_stub
       @control_stub ||= CONTROL_CLIENT_STUB_CLASS.new(@control_endpoint, combined_credentials,
-          channel_args: { 'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution here
+            channel_args: { 'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution here
       )
     end
 

--- a/lib/momento/cache_client.rb
+++ b/lib/momento/cache_client.rb
@@ -346,7 +346,8 @@ module Momento
         CACHE_CLIENT_STUB_CLASS.new(@cache_endpoint, combined_credentials,
           timeout: @configuration.transport_strategy.grpc_configuration.deadline,
           channel_args: { 'grpc.use_local_subchannel_pool' => 1,
-                          'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution to avoid DNS TXT record lookups
+                          # Disable service config resolution to avoid DNS TXT record lookups
+                          'grpc.service_config_disable_resolution' => 1 }
         )
       }
       @next_cache_stub_index = (@next_cache_stub_index + 1) % @num_cache_stubs
@@ -355,7 +356,8 @@ module Momento
 
     def control_stub
       @control_stub ||= CONTROL_CLIENT_STUB_CLASS.new(@control_endpoint, combined_credentials,
-        channel_args: { 'grpc.service_config_disable_resolution' => 1 } # Disable service config resolution to avoid DNS TXT record lookups
+        # Disable service config resolution to avoid DNS TXT record lookups
+        channel_args: { 'grpc.service_config_disable_resolution' => 1 }
       )
     end
 

--- a/spec/momento/cache_client_spec.rb
+++ b/spec/momento/cache_client_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Momento::CacheClient do
 
       expect(stub_class).to have_received(:new)
         .with(endpoint, instance_of(GRPC::Core::ChannelCredentials), { timeout: 5000,
-channel_args: { "grpc.use_local_subchannel_pool" => 1 } }
+channel_args: { "grpc.use_local_subchannel_pool" => 1, "grpc.service_config_disable_resolution" => 1 } }
         )
     end
   end
@@ -63,7 +63,9 @@ channel_args: { "grpc.use_local_subchannel_pool" => 1 } }
       stub
 
       expect(stub_class).to have_received(:new)
-        .with(endpoint, instance_of(GRPC::Core::ChannelCredentials))
+        .with(endpoint, instance_of(GRPC::Core::ChannelCredentials),
+              channel_args: {"grpc.service_config_disable_resolution" => 1 }
+        )
     end
   end
 

--- a/spec/momento/cache_client_spec.rb
+++ b/spec/momento/cache_client_spec.rb
@@ -64,7 +64,7 @@ channel_args: { "grpc.use_local_subchannel_pool" => 1, "grpc.service_config_disa
 
       expect(stub_class).to have_received(:new)
         .with(endpoint, instance_of(GRPC::Core::ChannelCredentials),
-              channel_args: {"grpc.service_config_disable_resolution" => 1 }
+          channel_args: {"grpc.service_config_disable_resolution" => 1 }
         )
     end
   end

--- a/spec/momento/cache_client_spec.rb
+++ b/spec/momento/cache_client_spec.rb
@@ -64,7 +64,7 @@ channel_args: { "grpc.use_local_subchannel_pool" => 1, "grpc.service_config_disa
 
       expect(stub_class).to have_received(:new)
         .with(endpoint, instance_of(GRPC::Core::ChannelCredentials),
-          channel_args: {"grpc.service_config_disable_resolution" => 1 }
+          channel_args: { "grpc.service_config_disable_resolution" => 1 }
         )
     end
   end


### PR DESCRIPTION
## PR Description:
- Based on the commit [here](https://github.com/googleapis/gax-ruby/pull/213/files), dynamic txt lookup for dns resolution flag is disabled by default in grpc-ruby.
- This commit explicitly disables it too.

### tcpdump when running existing example without adding the flag explicitly:
```
sudo tcpdump -i any -vvv port 53 | grep -i cache.cell-alpha-dev.preprod.a.momentohq.com           ─╯
Password:
tcpdump: data link type PKTAP
tcpdump: listening on any, link-type PKTAP (Apple DLT_PKTAP), snapshot length 524288 bytes
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.63435: [udp sum ok] 47488 q: A? control.cell-alpha-dev.preprod.a.momentohq.com. 2/0/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com., cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (100)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.63435: [udp sum ok] 44711 q: AAAA? control.cell-alpha-dev.preprod.a.momentohq.com. 1/1/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com. ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (168)
    10.0.0.249.63121 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 25632+ A? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    10.0.0.249.63121 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 9524+ AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.63121: [udp sum ok] 25632 q: A? cache.cell-alpha-dev.preprod.a.momentohq.com. 1/0/0 cache.cell-alpha-dev.preprod.a.momentohq.com. [59s] A 54.186.170.81 (78)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.63121: [udp sum ok] 9524 q: AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. 0/1/0 ns: cell-alpha-dev.preprod.a.momentohq.com. [14m59s] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (146)
    10.0.0.249.63121 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 7722+ AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com.vs.shawcable.net. (79)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.63121: [udp sum ok] 7722 NXDomain q: AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com.vs.shawcable.net. 0/1/0 ns: vs.shawcable.net. [10m] SOA pd1ns1.st.vc.shawcable.net. dnsadmin.shaw.ca. 2196234168 10800 3600 604800 600 (144)
```

Observe no txt lookups with current version of ruby sdk [(v 0.5.2)](https://github.com/momentohq/client-sdk-ruby/releases/tag/momento%2Fv0.5.2)

## Relevant Research Links:
- https://github.com/googleapis/gapic-generator/issues/2778
- https://github.com/googleapis/gax-ruby/pull/213/files


## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1132