### PR TITLE
chore: update tests, examples, CI for api keys v2

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets:
       api-key: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      api-key-v2: ${{ secrets.ALPHA_API_KEY_V2 }}
 
   readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -33,3 +33,4 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets:
       api-key: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      api-key-v2: ${{ secrets.ALPHA_API_KEY_V2 }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       api-key:
         description: 'API key used for live testing'
         required: false
+      api-key-v2:
+        description: 'v2 API key used for live testing'
+        required: false
     inputs:
       cache-name:
         description: 'The cache name to use for live testing'
@@ -34,5 +37,7 @@ jobs:
     - name: Run tests
       run: bundle exec rspec
       env:
-        MOMENTO_API_KEY: ${{ secrets.api-key }}
+        MOMENTO_ENDPOINT: "cell-alpha-dev.preprod.a.momentohq.com"
+        MOMENTO_API_KEY: ${{ secrets.api-key-v2 }}
+        V1_API_KEY: ${{ secrets.api-key }}
         TEST_CACHE_NAME: ${{ inputs.cache-name }}-${{ matrix.ruby-version }}-${{github.sha}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,8 @@ You can also build a gem from local sources and install it. Run `bundle exec rak
 ## Running tests
 
 You will need a momento API key that you can generate on the [Momento Console](https://console.gomomento.com/api-keys).
-1. Set the environment variable `MOMENTO_API_KEY` to your Momento API key.
+
+1. Set the environment variable `MOMENTO_API_KEY` to your v2 Momento API key, `MOMENTO_ENDPOINT` to chosen endpoint, and `V1_API_KEY` to your v1 API key.
 2. Optionally set the environment variable `TEST_CACHE_NAME` to a cache that is safe to test with and delete. If you don't do this, the cache 'ruby-test-cache' will be used by default.
 3. Run `rspec` from the command line to execute the tests.
 

--- a/README.template.md
+++ b/README.template.md
@@ -47,8 +47,8 @@ General documentation on Momento and the Momento SDKs is available on the [Momen
 
 To get started with Momento you will need:
 
-- A Momento API key. You can get one from the [Momento Console](https://console.gomomento.com).
-- A Momento service endpoint is required. You can find a [list of them here](https://docs.momentohq.com/platform/regions)
+* A Momento API key. You can get one from the [Momento Console](https://console.gomomento.com).
+* A Momento service endpoint is required. You can find a [list of them here](https://docs.momentohq.com/platform/regions)
 
 ## Examples
 

--- a/README.template.md
+++ b/README.template.md
@@ -11,7 +11,7 @@ To get started with Momento you will need a Momento API key. You can get one fro
 
 ## Packages
 
-The Momento Ruby SDK is available on [RubyGems](https://rubygems.org/gems/momento) 
+The Momento Ruby SDK is available on [RubyGems](https://rubygems.org/gems/momento)
 
 Install the gem and add to an application's Gemfile by executing:
 
@@ -43,7 +43,12 @@ You can find this example code and more in [the examples directory](./examples) 
 
 ## Getting Started and Documentation
 
-General documentation on Momento and the Momento SDKs is available on the [Momento Docs website](https://docs.momentohq.com/). Specific usage examples for the Ruby SDK are coming soon!
+General documentation on Momento and the Momento SDKs is available on the [Momento Docs website](https://docs.momentohq.com/).
+
+To get started with Momento you will need:
+
+- A Momento API key. You can get one from the [Momento Console](https://console.gomomento.com).
+- A Momento service endpoint is required. You can find a [list of them here](https://docs.momentohq.com/platform/regions)
 
 ## Examples
 

--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem 'momento', '~> 0.5.2'
+gem 'momento', '~> 0.6.4'

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ Then, set the required environment variables:
 
 ```bash
 export MOMENTO_API_KEY=<YOUR_API_KEY>
+export MOMENTO_ENDPOINT=<YOUR_ENDPOINT>
 ```
 
 And now you can run the example programs.

--- a/examples/compact.rb
+++ b/examples/compact.rb
@@ -8,8 +8,8 @@ TTL_SECONDS = 10
 # The name of the cache to create *and delete*
 CACHE_NAME = ENV.fetch('MOMENTO_CACHE_NAME', 'ruby-examples')
 
-# Create a credential provider that loads a Momento API Key from an environment variable.
-credential_provider = Momento::CredentialProvider.from_env_var('MOMENTO_API_KEY')
+# Create a credential provider that loads a Momento API Key and endpoint from an environment variables.
+credential_provider = Momento::CredentialProvider.from_env_var_v2
 
 # Instantiate a Momento client.
 client = Momento::CacheClient.new(

--- a/examples/compact.rb
+++ b/examples/compact.rb
@@ -8,7 +8,7 @@ TTL_SECONDS = 10
 # The name of the cache to create *and delete*
 CACHE_NAME = ENV.fetch('MOMENTO_CACHE_NAME', 'ruby-examples')
 
-# Create a credential provider that loads a Momento API Key and endpoint from an environment variables.
+# Create a credential provider that loads a Momento API Key and endpoint from environment variables.
 credential_provider = Momento::CredentialProvider.from_env_var_v2
 
 # Instantiate a Momento client.

--- a/examples/example.rb
+++ b/examples/example.rb
@@ -9,8 +9,8 @@ TTL_SECONDS = 12.5
 # The name of the cache to create *and delete*
 CACHE_NAME = ENV.fetch('MOMENTO_CACHE_NAME', 'ruby-examples')
 
-# Create a credential provider that loads a Momento API Key from an environment variable.
-credential_provider = Momento::CredentialProvider.from_env_var('MOMENTO_API_KEY')
+# Create a credential provider that loads a Momento API Key and endpoint from an environment variables.
+credential_provider = Momento::CredentialProvider.from_env_var_v2
 
 # This is a reasonable configuration for dev work on a laptop.
 configuration = Momento::Cache::Configurations::Laptop.latest

--- a/examples/example.rb
+++ b/examples/example.rb
@@ -9,7 +9,7 @@ TTL_SECONDS = 12.5
 # The name of the cache to create *and delete*
 CACHE_NAME = ENV.fetch('MOMENTO_CACHE_NAME', 'ruby-examples')
 
-# Create a credential provider that loads a Momento API Key and endpoint from an environment variables.
+# Create a credential provider that loads a Momento API Key and endpoint from environment variables.
 credential_provider = Momento::CredentialProvider.from_env_var_v2
 
 # This is a reasonable configuration for dev work on a laptop.

--- a/examples/file.rb
+++ b/examples/file.rb
@@ -18,7 +18,7 @@ FILE_LOCATIONS = [
   "../spec/support/assets/test.jpg"
 ].freeze
 
-# Create a credential provider that loads a Momento API Key and endpoint from an environment variables.
+# Create a credential provider that loads a Momento API Key and endpoint from environment variables.
 credential_provider = Momento::CredentialProvider.from_env_var_v2
 
 # Instantiate a Momento client.

--- a/examples/file.rb
+++ b/examples/file.rb
@@ -18,8 +18,8 @@ FILE_LOCATIONS = [
   "../spec/support/assets/test.jpg"
 ].freeze
 
-# Create a credential provider that loads a Momento API Key from an environment variable.
-credential_provider = Momento::CredentialProvider.from_env_var('MOMENTO_API_KEY')
+# Create a credential provider that loads a Momento API Key and endpoint from an environment variables.
+credential_provider = Momento::CredentialProvider.from_env_var_v2
 
 # Instantiate a Momento client.
 client = Momento::CacheClient.new(

--- a/spec/integration/client_state_manager.rb
+++ b/spec/integration/client_state_manager.rb
@@ -4,13 +4,21 @@ module ClientStateManager
     def cache_client
       @cache_client ||= Momento::CacheClient.new(
         configuration: Momento::Cache::Configurations::Laptop.latest,
-        credential_provider: Momento::CredentialProvider.from_env_var('MOMENTO_API_KEY'),
+        credential_provider: Momento::CredentialProvider.from_env_var('V1_API_KEY'),
         default_ttl: 60 # seconds
       )
     end
 
     def cache_name
       @cache_name ||= ENV.fetch('TEST_CACHE_NAME', 'ruby-test-cache')
+    end
+
+    def cache_client_v2
+      @cache_client_v2 ||= Momento::CacheClient.new(
+        configuration: Momento::Cache::Configurations::Laptop.latest,
+        credential_provider: Momento::CredentialProvider.from_env_var_v2,
+        default_ttl: 60 # seconds
+      )
     end
   end
 end

--- a/spec/integration/momento/cache_client_api_keys_v2_spec.rb
+++ b/spec/integration/momento/cache_client_api_keys_v2_spec.rb
@@ -1,0 +1,344 @@
+require 'momento'
+require_relative '../spec_helper'
+
+RSpec.describe Momento::CacheClient do
+  let(:client) {
+    ClientStateManager.cache_client_v2
+  }
+  let(:cache_name) {
+    ClientStateManager.cache_name
+  }
+  let(:key) {
+    generate_random_string
+  }
+  let(:value) {
+    generate_random_string
+  }
+  let(:sorted_set_name) {
+    generate_random_string
+  }
+  let(:score) {
+    1.0
+  }
+
+  describe '#create_cache' do
+    subject {
+      client.create_cache(cache_name)
+    }
+
+    it_behaves_like 'it handles invalid caches'
+  end
+
+  describe '#delete_cache' do
+    subject {
+      client.delete_cache(cache_name)
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when deleting a cache that exists' do
+      let(:cache_name) {
+        generate_random_string
+      }
+
+      before {
+        client.create_cache(cache_name)
+      }
+
+      it 'succeeds' do
+        expect(client.list_caches).to have_attributes(
+          success?: true,
+          cache_names: include(cache_name)
+        )
+
+        expect(client.delete_cache(cache_name)).to be_success
+
+        response = client.list_caches
+        expect(response).to have_attributes(success?: true)
+        expect(response.cache_names).not_to include(cache_name)
+      end
+    end
+  end
+
+  describe '#list_caches' do
+    subject {
+      client.list_caches
+    }
+
+    context 'when listing caches' do
+      it 'includes all caches' do
+        expect(client.list_caches).to have_attributes(
+          success?: true,
+          cache_names: include(cache_name)
+        )
+      end
+    end
+  end
+
+  describe '#get' do
+    subject {
+      client.get(cache_name, key)
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when the key has no value on the server' do
+      it 'returns a miss' do
+        is_expected.to have_attributes(
+          hit?: false,
+          miss?: true,
+          error?: false
+        )
+      end
+    end
+
+    context 'when the key has a value on the server' do
+      before {
+        client.set(cache_name, key, value)
+      }
+
+      it 'returns a hit' do
+        is_expected.to have_attributes(
+          hit?: true,
+          miss?: false,
+          error?: false,
+          error: nil,
+          value_string: value
+        )
+      end
+    end
+  end
+
+  describe '#set' do
+    subject {
+      client.set(cache_name, key, value)
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when writing a string' do
+      it 'sets it' do
+        expect(client.set(cache_name, key, value)).to be_success
+
+        expect(client.get(cache_name, key))
+          .to have_attributes(
+            hit?: true,
+            value_string: value
+          )
+      end
+    end
+
+    context 'when writing binary data' do
+      let(:value) {
+        File.read("spec/support/assets/test.jpg", encoding: Encoding::ASCII_8BIT)
+      }
+
+      it 'sets it' do
+        expect(client.set(cache_name, key, value)).to be_success
+
+        expect(client.get(cache_name, key))
+          .to have_attributes(
+            hit?: true,
+            value_bytes: value
+          )
+      end
+    end
+
+    context 'when writing a value with a short ttl' do
+      it 'succeeds and the value times out before it can be read' do
+        expect(client.set(cache_name, key, value, ttl: 1)).to be_success
+
+        sleep(2)
+
+        expect(client.get(cache_name, key)).to have_attributes(miss?: true)
+      end
+    end
+  end
+
+  describe '#delete' do
+    subject {
+      client.delete(cache_name, key)
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when deleting a value' do
+      it 'deletes successfully' do
+        client.set(cache_name, key, value)
+
+        expect(client.delete(cache_name, key)).to have_attributes(success?: true)
+        expect(client.get(cache_name, key)).to have_attributes(miss?: true)
+      end
+
+      it 'succeeds even if the value does not exist' do
+        expect(client.delete(cache_name, key)).to have_attributes(success?: true)
+        expect(client.get(cache_name, key)).to have_attributes(miss?: true)
+      end
+    end
+  end
+
+  describe '#sorted_set_put_element' do
+    subject {
+      client.sorted_set_put_element(cache_name, sorted_set_name, value, score)
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when writing a string' do
+      it 'succeeds' do
+        expect(subject).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_string_elements: [{ value: value, score: 1.0 }]
+              )
+      end
+
+      it 'overwrites existing values' do
+        expect(subject).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_string_elements: [{ value: value, score: 1.0 }]
+              )
+
+        expect(client.sorted_set_put_element(cache_name, sorted_set_name, value, 999.0)).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_string_elements: [{ value: value, score: 999.0 }]
+              )
+      end
+    end
+
+    context 'when writing binary data' do
+      let(:value) {
+        File.read("spec/support/assets/test.jpg", encoding: Encoding::ASCII_8BIT)
+      }
+
+      it 'succeeds' do
+        expect(subject).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_bytes_elements: [{ value: value, score: 1.0 }]
+              )
+      end
+    end
+
+    context 'when writing an element with a short ttl' do
+      it 'succeeds and the element times out before it can be read' do
+        expect(client.sorted_set_put_element(cache_name, sorted_set_name, value, score,
+          collection_ttl: Momento::CollectionTtl.of(1)
+        )
+              ).to be_success
+
+        sleep(2)
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(miss?: true)
+      end
+    end
+  end
+
+  describe '#sorted_set_put_elements' do
+    subject {
+      client.sorted_set_put_elements(cache_name, sorted_set_name, { value => score })
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when writing String' do
+      it 'succeeds' do
+        expect(client.sorted_set_put_elements(cache_name, sorted_set_name, [[value, score], ['a', 0.0]])).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_string_elements: [{ value: 'a', score: 0.0 }, { value: value, score: 1.0 }]
+              )
+      end
+    end
+
+    context 'when writing binary data' do
+      let(:value) {
+        File.read("spec/support/assets/test.jpg", encoding: Encoding::ASCII_8BIT)
+      }
+
+      it 'succeeds' do
+        expect(client.sorted_set_put_elements(cache_name, sorted_set_name, { value => score })).to be_success
+
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name))
+          .to have_attributes(
+                value_bytes_elements: [{ value: value, score: 1.0 }]
+              )
+      end
+    end
+  end
+
+  describe '#sorted_set_fetch_by_score' do
+    subject {
+      client.sorted_set_fetch_by_score(cache_name, sorted_set_name)
+    }
+
+    it_behaves_like 'it handles invalid caches'
+    it_behaves_like 'it handles non-existent caches'
+
+    context 'when fetching a non-existent set' do
+      it 'misses' do
+        expect(client.sorted_set_fetch_by_score(cache_name, sorted_set_name)).to have_attributes(miss?: true)
+      end
+    end
+
+    context 'when fetching string data' do
+      before {
+        client.sorted_set_put_elements(cache_name, sorted_set_name, {
+          '1' => 0.0,
+          '2' => 1.0,
+          '3' => 0.5,
+          '4' => 2.0,
+          '5' => 1.5
+        }
+        )
+      }
+
+      it 'is able to fetch a full set ascending, with an end score larger than any in the set' do
+        response = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, min_score: 0.0, max_score: 9.9)
+        expect(response).to have_attributes(hit?: true)
+
+        values = response.value&.map { |hash| hash[:value] }
+        expect(values).to eq(%w[1 3 2 5 4])
+      end
+
+      it 'is able to fetch part of the set descending, limited by the scores' do
+        response = client.sorted_set_fetch_by_score(cache_name, sorted_set_name,
+          sort_order: Momento::SortOrder::DESCENDING, min_score: 0.1, max_score: 1.9
+        )
+        expect(response).to have_attributes(hit?: true)
+
+        values = response.value_string_elements&.map { |hash| hash[:value] }
+        expect(values).to eq(%w[5 2 3])
+      end
+
+      it 'is able to fetch part of the set, limited by offset and count' do
+        response = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, offset: 1, count: 3)
+        expect(response).to have_attributes(hit?: true)
+
+        values = response.value_string_elements&.map { |hash| hash[:value] }
+        expect(values).to eq(%w[3 2 5])
+      end
+
+      it 'returns a hit with no elements if the set exists, but the parameters do not match anything' do
+        response = client.sorted_set_fetch_by_score(cache_name, sorted_set_name, offset: 9999)
+        expect(response).to have_attributes(hit?: true)
+
+        expect(response.value_string_elements).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1276

1. updates github actions workflows to use env vars V1_API_KEY, MOMENTO_API_KEY, and MOMENTO_ENDPOINT
2. updates readmes for new env vars
3. updates examples to default to using from_environment_variables_v2()
4. existing tests now use V1_API_KEY
5. adds new minimal test suites exercising v2 api key use MOMENTO_API_KEY and MOMENTO_ENDPOINT

Note: there does not seem to be a docs snippet file in this repo's examples